### PR TITLE
Support Source availability checker

### DIFF
--- a/lib/topological_inventory/orchestrator/source_type.rb
+++ b/lib/topological_inventory/orchestrator/source_type.rb
@@ -4,6 +4,7 @@ module TopologicalInventory
   module Orchestrator
     class SourceType < ApiObject
       SUPPORTED_TYPES = %w[amazon ansible-tower azure openshift].freeze
+      AVAILABILITY_CHECK_SOURCE_TYPES = %w[amazon ansible-tower openshift].freeze
 
       def to_s
         attributes['name'] || "Unknown source type: #{attributes.inspect}"
@@ -34,6 +35,10 @@ module TopologicalInventory
         define_method "#{type.sub('-', '_')}?" do
           attributes['name'].to_s == type
         end
+      end
+
+      def supports_availability_check?
+        AVAILABILITY_CHECK_SOURCE_TYPES.include?(attributes['name'])
       end
     end
   end

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -125,6 +125,10 @@ module TopologicalInventory
               next
             end
 
+            if source_type.supports_availability_check?
+              next unless attributes["availability_status"] == "available"
+            end
+
             Source.new(attributes, tenant, source_type, collector_definition, :from_sources_api => true).tap do |source|
               source.load_credentials(@api)
 

--- a/spec/helpers/functions.rb
+++ b/spec/helpers/functions.rb
@@ -4,6 +4,8 @@ module Functions
   # API call stubs for Source, endpoint, authentication(and credentials)
   def stub_api_source_calls(source)
     stub_api_source_get(source, show(source))
+    return unless source_available?(source)
+
     endpoint = endpoints(source)[source['id']]
     stub_rest_get("#{sources_api}/sources/#{source["id"]}/endpoints", user_tenant_header, list([endpoint]))
 


### PR DESCRIPTION
Only consider a source for the orchestration if it's marked as available by the new availability_checker.

Marking as WIP for now as this
Depends on:
 - [x] https://github.com/ManageIQ/sources-api/pull/59
 - [x] https://github.com/ManageIQ/topological_inventory-openshift/pull/95
 - [x] https://github.com/ManageIQ/sources-api-client-ruby/pull/5

