### PR TITLE
Add bundler-inject to orchestrator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+plugin "bundler-inject", "~> 1.1"
+require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
+
 gem "cloudwatchlogger", "~>0.2"
 gem "kubeclient", "~>4.0"
 gem "manageiq-loggers", "~>0.4"


### PR DESCRIPTION
The bundler-inject plugin was never added to the orchestrator