### PR TITLE
Catch all exceptions from tp-inv source's refresh_status update

### DIFF
--- a/lib/topological_inventory/orchestrator/api.rb
+++ b/lib/topological_inventory/orchestrator/api.rb
@@ -60,8 +60,8 @@ module TopologicalInventory
           {:refresh_status => refresh_status}.to_json,
           tenant_header(source["tenant"])
         )
-      rescue RestClient::NotFound
-        logger.error("Failed to update 'refresh_status' on source #{source["id"]}")
+      rescue StandardError => e
+        logger.error("Failed to update 'refresh_status' on source #{source["id"]}\n#{e.message}\n#{e.backtrace.join("\n")}")
       end
 
       private


### PR DESCRIPTION
Updating of refresh status isn't critical operation for orchestrator, so 500 error exception shouln't stop orchestrator from processing.