### PR TITLE
More sources per collector

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,8 +1,8 @@
 collectors:
   sources_per_collector:
-    amazon: 2
-    ansible-tower: 2
-    azure: 2
+    amazon: 10
+    ansible-tower: 10
+    azure: 10
     openshift: 2
 sync:
   poll_time_seconds: 10


### PR DESCRIPTION
Sources in collectors are processed by thread pool with queue, so more sources can be assigned without higher memory requirements

---

-  [ ] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/11