### PR TITLE
Decrease Towers count in collector

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,7 +1,7 @@
 collectors:
   sources_per_collector:
     amazon: 10
-    ansible-tower: 10
+    ansible-tower: 2
     azure: 10
     openshift: 2
 sync:


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-ansible_tower/issues/72

Decreasing Sources per collector for Tower to 2. 

Doesn't affect current Sources <-> Collector(ConfigMap) distribution. 
Source will be moved to new collector(config map) if `digest` changes - it means endpoint or authentication values.