### PR TITLE
Fixed event driven Source update

### DIFF
--- a/lib/topological_inventory/orchestrator/config_map.rb
+++ b/lib/topological_inventory/orchestrator/config_map.rb
@@ -348,7 +348,7 @@ module TopologicalInventory
       end
 
       def digests
-        return @digests if @digests.present?
+        return @digests if @digests
 
         @digests = if openshift_object&.data&.digests.present?
                      JSON.parse(openshift_object.data.digests)

--- a/spec/helpers/functions.rb
+++ b/spec/helpers/functions.rb
@@ -152,13 +152,13 @@ module Functions
     expect(kube_client.secrets.size).to eq(cnt)
   end
 
-  def assert_openshift_objects_data(source_data, endpoint_data: nil, auth_data: nil, missing: false)
-    config_uid = assert_source_in_config_maps(source_data, :endpoint_data => endpoint_data, :missing => missing)
+  def assert_openshift_objects_data(source_data, endpoint_data: nil, auth_data: nil, digest: nil, missing: false)
+    config_uid = assert_source_in_config_maps(source_data, :endpoint_data => endpoint_data, :digest => digest, :missing => missing)
     assert_source_in_secrets(source_data, config_uid, :auth_data => auth_data, :missing => missing)
   end
 
   # @param endpoint_data [Hash] if not present, data are loaded from defaults (mock_data.rb#endpoints)
-  def assert_source_in_config_maps(source_data, endpoint_data: nil, missing: false)
+  def assert_source_in_config_maps(source_data, endpoint_data: nil, digest: nil, missing: false)
     found_digests, found_in_yaml = 0, 0
     config_uid = nil
 
@@ -172,7 +172,8 @@ module Functions
       expect(config_map.data.digests).to be_present
       digests = JSON.parse(config_map.data.digests)
 
-      if (found_digest = digests.include?(digests_data[source_data['id']]))
+      # Try to find either given digest (changed Source) or in predefined data
+      if (found_digest = digests.include?(digest || digests_data[source_data['id']]))
         found_digests += 1
 
         # When found, check that source is in config_map of the same source_type

--- a/spec/targeted_update_spec.rb
+++ b/spec/targeted_update_spec.rb
@@ -206,6 +206,7 @@ describe TopologicalInventory::Orchestrator::TargetedUpdate do
     it "updates sources and keeps others unchanged" do
       changed_source = sources_data[:openshift][@id1].merge('name' => 'Changed!')
       changed_endpoint = endpoints[@id3].merge('host' => 'my-testing-url.com')
+      changed_digest = 'eb5c76b3094e1f3691e6c710403acdcf17c92e04'
 
       subject.add_target('Source', 'update', changed_source)
       subject.add_target('Endpoint', 'update', changed_endpoint)
@@ -214,13 +215,12 @@ describe TopologicalInventory::Orchestrator::TargetedUpdate do
                              :belongs_to        => {:source => [@id3]},
                              :has_one           => {:application => [@id1, @id3], :endpoint => [@id1], :authentication => [@id1, @id3], :credentials => [@id1, @id3]},
                              :request_app_types => false)
-
       subject.sync_targets_with_openshift
 
       assert_openshift_objects_count(3) # no change
       assert_openshift_objects_data(changed_source)
       assert_openshift_objects_data(sources_data[:openshift][@id2]) # no change
-      assert_openshift_objects_data(sources_data[:amazon][@id3], :endpoint_data => changed_endpoint)
+      assert_openshift_objects_data(sources_data[:amazon][@id3], :endpoint_data => changed_endpoint, :digest => changed_digest)
       assert_openshift_objects_data(sources_data[:amazon][@id4]) # no change
     end
 


### PR DESCRIPTION
lazy load of config map's digests has to test nil, not blank. 

In case of updating source in config map with this source only, old digest isn't deleted, because instance variable is reloaded before saving.

**Note**: It cannot "defragment" current state, but it releases free slots in config maps