### PR TITLE
Reloading OpenShift objects after updating

### DIFF
--- a/lib/topological_inventory/orchestrator/config_map.rb
+++ b/lib/topological_inventory/orchestrator/config_map.rb
@@ -345,6 +345,7 @@ module TopologicalInventory
         openshift_object.data['custom.yml'] = data_yaml
 
         object_manager.update_config_map(openshift_object)
+        openshift_object(:reload => true)
       end
 
       def digests

--- a/lib/topological_inventory/orchestrator/openshift_object.rb
+++ b/lib/topological_inventory/orchestrator/openshift_object.rb
@@ -10,8 +10,8 @@ module TopologicalInventory
         self.openshift_object = openshift_object
       end
 
-      def openshift_object
-        return @openshift_object if @openshift_object.present?
+      def openshift_object(reload: false)
+        return @openshift_object if @openshift_object.present? && !reload
 
         @openshift_object = load_openshift_object
       end

--- a/lib/topological_inventory/orchestrator/secret.rb
+++ b/lib/topological_inventory/orchestrator/secret.rb
@@ -34,7 +34,8 @@ module TopologicalInventory
 
         if openshift_object.present?
           openshift_object.stringData = data
-          object_manager.update_secret(openshift_object)
+          save_secret
+
 
           logger.info("[OK] Updated Secret #{self}")
         else
@@ -55,7 +56,7 @@ module TopologicalInventory
           credentials['updated_at'] = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S")
 
           openshift_object.stringData = { "credentials" => credentials.to_json }
-          object_manager.update_secret(openshift_object)
+          save_secret
 
           logger.info("[OK] Updated Secret #{self}")
         else
@@ -78,7 +79,7 @@ module TopologicalInventory
           credentials['updated_at'] = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S")
 
           openshift_object.stringData = { "credentials" => credentials.to_json }
-          object_manager.update_secret(openshift_object)
+          save_secret
 
           logger.info("[OK] Updated Secret #{self}")
         else
@@ -114,6 +115,11 @@ module TopologicalInventory
       end
 
       private
+
+      def save_secret
+        object_manager.update_secret(openshift_object)
+        openshift_object(:reload => true)
+      end
 
       def load_openshift_object
         object_manager.get_secrets(LABEL_COMMON).detect { |s| s.metadata.labels[LABEL_UNIQUE] == uid }

--- a/spec/config_map_spec.rb
+++ b/spec/config_map_spec.rb
@@ -78,6 +78,8 @@ describe TopologicalInventory::Orchestrator::ConfigMap do
         allow(object_manager).to receive(:update_config_map)
 
         expect(object_manager).to receive(:update_config_map).twice
+        # reload after update
+        expect(config_map).to receive(:load_openshift_object).and_return(openshift_object).twice
 
         # Add both sources to config map
         [source, source2].each do |s|
@@ -164,6 +166,7 @@ describe TopologicalInventory::Orchestrator::ConfigMap do
                                            :from_sources_api => true)
 
         allow(object_manager).to receive(:update_config_map)
+
         allow(object_manager).to receive(:delete_config_map)
 
         allow(secret).to receive(:delete_in_openshift)
@@ -172,6 +175,8 @@ describe TopologicalInventory::Orchestrator::ConfigMap do
 
         # 2x add, 1x remove, last remove doesn't update, but delete
         expect(object_manager).to receive(:update_config_map).exactly(3).times
+        # reload after update
+        expect(config_map).to receive(:load_openshift_object).and_return(openshift_object).exactly(3).times
         expect(secret).to receive(:update!).exactly(3).times
 
         # Add both sources to config map


### PR DESCRIPTION
TPINVTRY-896

When config maps can contain more sources, they need to be updated multiple times. And they have to be reloaded (by kube api) each time after saving.

Otherwise this error will happen:
`Operation cannot be fulfilled on configmaps \"config-ansible-tower-a8b13076-152b-44d7-9269-f27440f95df9\": the object has been modified; please apply your changes to the latest version and try again`