### PR TITLE
Maintaining objects by version

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,9 @@ collectors:
     ansible-tower: 2
     azure: 10
     openshift: 2
+labels:
+  # "True" is current version (it's like "v1")
+  version: "true"
 sync:
   poll_time_seconds: 10
   scheduled_event_hours: 1

--- a/lib/topological_inventory/orchestrator/config_map.rb
+++ b/lib/topological_inventory/orchestrator/config_map.rb
@@ -161,7 +161,7 @@ module TopologicalInventory
         logger.info("Creating ConfigMap #{self} by Source #{source}")
 
         object_manager.create_config_map(name) do |map|
-          map[:metadata][:labels][LABEL_COMMON] = "true"
+          map[:metadata][:labels][LABEL_COMMON] = ::Settings.labels.version.to_s
           map[:metadata][:labels][LABEL_SOURCE_TYPE] = source_type['name'] if source_type.present?
           map[:metadata][:labels][LABEL_UNIQUE] = uid
           map[:data][:uid] = uid

--- a/lib/topological_inventory/orchestrator/deployment_config.rb
+++ b/lib/topological_inventory/orchestrator/deployment_config.rb
@@ -31,7 +31,7 @@ module TopologicalInventory
         logger.info("Creating DeploymentConfig #{self}")
         object_manager.create_deployment_config(name, ENV["IMAGE_NAMESPACE"], image) do |dc|
           dc[:metadata][:labels][LABEL_UNIQUE] = uid
-          dc[:metadata][:labels][LABEL_COMMON] = "true"
+          dc[:metadata][:labels][LABEL_COMMON] = ::Settings.labels.version.to_s
           dc[:metadata][:labels][ConfigMap::LABEL_SOURCE_TYPE] = config_map.source_type['name'] if config_map.source_type.present?
           dc[:spec][:replicas] = 1
 

--- a/lib/topological_inventory/orchestrator/secret.rb
+++ b/lib/topological_inventory/orchestrator/secret.rb
@@ -20,7 +20,7 @@ module TopologicalInventory
 
         object_manager.create_secret(name, data) do |secret|
           secret[:metadata][:labels][LABEL_UNIQUE] = uid
-          secret[:metadata][:labels][LABEL_COMMON] = "true"
+          secret[:metadata][:labels][LABEL_COMMON] = ::Settings.labels.version.to_s
           secret[:metadata][:labels][ConfigMap::LABEL_SOURCE_TYPE] = config_map.source_type['name'] if config_map.source_type.present?
         end
 

--- a/lib/topological_inventory/orchestrator/targeted_update.rb
+++ b/lib/topological_inventory/orchestrator/targeted_update.rb
@@ -94,7 +94,7 @@ module TopologicalInventory
       def load_config_maps
         @config_maps_by_uid = {}
 
-        object_manager.get_config_maps("#{ConfigMap::LABEL_COMMON}=true").each do |openshift_object|
+        object_manager.get_config_maps("#{ConfigMap::LABEL_COMMON}=#{::Settings.labels.version}").each do |openshift_object|
           config_map = ConfigMap.new(object_manager, openshift_object)
           config_map.targeted_update = true
 

--- a/spec/config_map_spec.rb
+++ b/spec/config_map_spec.rb
@@ -2,6 +2,7 @@ require 'yaml'
 
 describe TopologicalInventory::Orchestrator::ConfigMap do
   include MockData
+  include Functions
 
   let(:object_manager) { double('object_manager') }
   let(:openshift_object) { double('openshift_object') }
@@ -30,6 +31,10 @@ describe TopologicalInventory::Orchestrator::ConfigMap do
 
     allow(secret).to receive(:config_map=)
     allow(deployment_config).to receive(:config_map=)
+
+    config_file = File.expand_path("../config/default.yml", File.dirname(__FILE__))
+    ::Config.load_and_set_settings(config_file)
+    init_config
   end
 
   describe "#init_from_source" do

--- a/spec/helpers/functions.rb
+++ b/spec/helpers/functions.rb
@@ -134,15 +134,19 @@ module Functions
     @api.send(:make_params_string, filter_key, filter_value, limit)
   end
 
-  def init_config(openshift: 1, amazon: 1, azure: 1, mock: 1)
-    stub_settings_merge(:collectors => {
-      :sources_per_collector => {
-        :amazon    => amazon,
-        :azure     => azure,
-        :mock      => mock,
-        :openshift => openshift
-      }
-    })
+  def init_config(openshift: 1, amazon: 1, azure: 1, mock: 1, version: "v1")
+    stub_settings_merge(
+      :collectors => {
+        :sources_per_collector => {
+          :amazon    => amazon,
+          :azure     => azure,
+          :mock      => mock,
+          :openshift => openshift
+        }
+      },
+      :labels     => {
+        :version => version
+      })
   end
 
   ### Assert checks agains kube_client


### PR DESCRIPTION
Orchestrator recognizes openshift objects by label version. Each type of object (DC, ConfigMap,Secret) has its own common label, currently with value "true":
- `tp-inventory/collector`
- `tp-inventory/collectors-secret`
- `tp-inventory/collectors-config-map`

When changed `label.version` value in config file, objects with different version will be deleted at the start of the orchestrator.

This is a prerequisity for safe renaming openshift objects.
Current version is set to "true", so this PR will do nothing.

