### PR TITLE
Fixed destroy events when source deleted from db

### DIFF
--- a/lib/topological_inventory/orchestrator/targeted_api.rb
+++ b/lib/topological_inventory/orchestrator/targeted_api.rb
@@ -19,10 +19,12 @@ module TopologicalInventory
           topology_source_ids << topology_source['id']
         end
 
-        filter = make_params_string(filter_key, topology_source_ids)
+        if topology_source_ids.present?
+          filter = make_params_string(filter_key, topology_source_ids)
 
-        each_resource(sources_api_url_for("sources?#{filter}"), external_tenant) do |source|
-          yield source
+          each_resource(sources_api_url_for("sources?#{filter}"), external_tenant) do |source|
+            yield source
+          end
         end
       end
 

--- a/lib/topological_inventory/orchestrator/targeted_update.rb
+++ b/lib/topological_inventory/orchestrator/targeted_update.rb
@@ -100,8 +100,8 @@ module TopologicalInventory
 
           @config_maps_by_uid[config_map.uid] = config_map
 
-          config_map.assign_source_type!(@targets.collect { |t| t[:source_type] })
-          config_map.associate_sources_by_targets(@targets)
+          config_map.assign_source_type!(@targets.collect { |t| t[:source_type] unless t[:action] == :skip }.compact)
+          config_map.associate_sources_by_targets(@targets.select { |t| t[:action] != :skip})
         end
 
         logger.debug("ConfigMaps loaded: #{@config_maps_by_uid.values.count}")
@@ -127,6 +127,8 @@ module TopologicalInventory
       end
 
       def skip_target(target)
+        return if target[:source].nil?
+
         log_msg_for_target(target, "Source #{target[:source]['id']} skipped", :info)
       end
 

--- a/lib/topological_inventory/orchestrator/targeted_update/api_load_has_one.rb
+++ b/lib/topological_inventory/orchestrator/targeted_update/api_load_has_one.rb
@@ -18,6 +18,7 @@ module TopologicalInventory
 
           targets.each do |target|
             next if target[dest_model].present? # Was loaded previously
+            next if target[src_model].nil? # Could be destroy event when Source was deleted before
 
             target_data = target[src_model]
             dest_id     = target_data['id'].to_i

--- a/lib/topological_inventory/orchestrator/targeted_update/skip_action_rules.rb
+++ b/lib/topological_inventory/orchestrator/targeted_update/skip_action_rules.rb
@@ -57,6 +57,12 @@ module TopologicalInventory
         def skip_targets_with_same_source_and_action
           @targets.each do |target|
             @targets.each do |target2|
+              # Skip incomplete targets
+              if target[:source].nil? || target2[:source].nil?
+                target[:action] = :skip
+                break
+              end
+
               next unless target[:source]['id'] == target2[:source]['id'] &&
                           target[:action] == target2[:action] &&
                           target[:target] != target2[:target]


### PR DESCRIPTION
When some Destroy event is processed, their relations in Sources API or Topological API or both needn't exist. 

This PR cover these cases