### PR TITLE
Add the ability to configure ENABLED_SOURCE_TYPES via ENV

### DIFF
--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -15,6 +15,8 @@ def parse_args
     opt :topology_api, "URL to the topological inventory service, e.g. http://localhost:4000/api/v0.1", :type => :string,
         :default => ENV["TOPOLOGICAL_INVENTORY_API"], :required => ENV["TOPOLOGICAL_INVENTORY_API"].nil?
     opt :config, "Configuration YAML file name", :type => :string, :default => ENV["CONFIG"] || 'default'
+    opt :source_types, "The Source types to spin up collectors/operations pods for", :type => :string,
+        :default => ENV['ENABLED_SOURCE_TYPES']&.split(",")
   end
 
   opts
@@ -32,5 +34,5 @@ Signal.trap("TERM") do
   exit
 end
 
-w = TopologicalInventory::Orchestrator::Worker.new(:collector_image_tag => args[:collector_image_tag], :sources_api => args[:sources_api], :topology_api => args[:topology_api], :config_name => args[:config])
+w = TopologicalInventory::Orchestrator::Worker.new(:collector_image_tag => args[:collector_image_tag], :sources_api => args[:sources_api], :topology_api => args[:topology_api], :config_name => args[:config], :source_types => args[:source_types])
 w.run

--- a/lib/topological_inventory/orchestrator/source_type.rb
+++ b/lib/topological_inventory/orchestrator/source_type.rb
@@ -3,7 +3,16 @@ require "topological_inventory/orchestrator/api_object"
 module TopologicalInventory
   module Orchestrator
     class SourceType < ApiObject
+      SUPPORTED_TYPES = %w[amazon ansible-tower azure openshift].freeze
       AVAILABILITY_CHECK_SOURCE_TYPES = %w[amazon ansible-tower openshift].freeze
+
+      def method_missing(name, *args, &block)
+        if name.to_s.ends_with?("?")
+          SUPPORTED_TYPES.include?(attributes['name'].to_s)
+        else
+          super
+        end
+      end
 
       def to_s
         attributes['name'] || "Unknown source type: #{attributes.inspect}"
@@ -27,13 +36,6 @@ module TopologicalInventory
 
       def supported_source_type?
         attributes['name'].present? && self[:enabled?]
-      end
-
-      # Methods amazon? / ansible_tower? / azure? / openshift?
-      %w[amazon ansible-tower azure openshift].each do |type|
-        define_method "#{type.sub('-', '_')}?" do
-          attributes['name'].to_s == type
-        end
       end
 
       def supports_availability_check?

--- a/lib/topological_inventory/orchestrator/source_type.rb
+++ b/lib/topological_inventory/orchestrator/source_type.rb
@@ -3,7 +3,6 @@ require "topological_inventory/orchestrator/api_object"
 module TopologicalInventory
   module Orchestrator
     class SourceType < ApiObject
-      SUPPORTED_TYPES = %w[amazon ansible-tower azure openshift].freeze
       AVAILABILITY_CHECK_SOURCE_TYPES = %w[amazon ansible-tower openshift].freeze
 
       def to_s
@@ -27,11 +26,11 @@ module TopologicalInventory
       end
 
       def supported_source_type?
-        attributes['name'].present? && SUPPORTED_TYPES.include?(attributes['name'])
+        attributes['name'].present? && self[:enabled?]
       end
 
       # Methods amazon? / ansible_tower? / azure? / openshift?
-      SUPPORTED_TYPES.each do |type|
+      %w[amazon ansible-tower azure openshift].each do |type|
         define_method "#{type.sub('-', '_')}?" do
           attributes['name'].to_s == type
         end

--- a/lib/topological_inventory/orchestrator/targeted_update.rb
+++ b/lib/topological_inventory/orchestrator/targeted_update.rb
@@ -17,6 +17,7 @@ module TopologicalInventory
         @collector_image_tag = worker.collector_image_tag
         @api = TargetedApi.new(:sources_api  => worker.api.sources_api,
                                :topology_api => worker.api.topology_api)
+        @enabled_source_types = worker.enabled_source_types
 
         clear_targets
       end
@@ -57,6 +58,8 @@ module TopologicalInventory
 
         load_sources_from_targets
 
+        enable_supported_source_types
+
         load_applications
 
         scan_targets!
@@ -71,6 +74,14 @@ module TopologicalInventory
       end
 
       private
+
+      def enable_supported_source_types
+        @targets.each do |target|
+          source_type = target[:source_type]
+
+          source_type[:enabled?] = @enabled_source_types.include?(source_type['name']) if source_type
+        end
+      end
 
       # Skips inconsistent data (if source not found) and noop destroy events
       # Assigns source type etc. to source

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -27,10 +27,11 @@ module TopologicalInventory
 
       ORCHESTRATOR_TENANT = "system_orchestrator".freeze
 
-      attr_reader :collector_image_tag, :api
+      attr_reader :collector_image_tag, :api, :enabled_source_types
 
-      def initialize(collector_image_tag:, sources_api:, topology_api:, config_name: 'default')
+      def initialize(collector_image_tag:, sources_api:, topology_api:, config_name: 'default', source_types: %w[amazon ansible-tower azure openshift])
         @collector_image_tag = collector_image_tag
+        @enabled_source_types = source_types
 
         self.config_name = config_name
         initialize_config
@@ -90,6 +91,8 @@ module TopologicalInventory
         @source_types_by_id = {}
 
         @api.each_source_type do |attributes|
+          attributes[:enabled?] = @enabled_source_types.include?(attributes['name'])
+
           if (source_type = SourceType.new(attributes)).supported_source_type?
             logger.debug("Loaded Source type: #{attributes['name']} | #{source_type.sources_per_collector} sources per config map")
           end

--- a/spec/worker_black_box_spec.rb
+++ b/spec/worker_black_box_spec.rb
@@ -212,7 +212,6 @@ describe TopologicalInventory::Orchestrator::Worker do
 
     context "with nonempty API data" do
       before do
-        stub_const("TopologicalInventory::Orchestrator::SourceType::SUPPORTED_TYPES", %w[openshift amazon azure])
         # Fill openshift first
         #
         # 1st sync


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-917

**Depends on:** 
- [x] https://github.com/RedHatInsights/e2e-deploy/pull/1537

In order to only deploy the supported GA collectors on prod, this PR changes the way the application deploys source types, it checks the ENV for which collectors to spin up. 