### PR TITLE
Change source_types option to a string instead of an array

### DIFF
--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -16,7 +16,7 @@ def parse_args
         :default => ENV["TOPOLOGICAL_INVENTORY_API"], :required => ENV["TOPOLOGICAL_INVENTORY_API"].nil?
     opt :config, "Configuration YAML file name", :type => :string, :default => ENV["CONFIG"] || 'default'
     opt :source_types, "The Source types to spin up collectors/operations pods for", :type => :string,
-        :default => ENV['ENABLED_SOURCE_TYPES']&.split(",")
+        :default => ENV['ENABLED_SOURCE_TYPES']
   end
 
   opts
@@ -34,5 +34,5 @@ Signal.trap("TERM") do
   exit
 end
 
-w = TopologicalInventory::Orchestrator::Worker.new(:collector_image_tag => args[:collector_image_tag], :sources_api => args[:sources_api], :topology_api => args[:topology_api], :config_name => args[:config], :source_types => args[:source_types])
+w = TopologicalInventory::Orchestrator::Worker.new(:collector_image_tag => args[:collector_image_tag], :sources_api => args[:sources_api], :topology_api => args[:topology_api], :config_name => args[:config], :source_types => args[:source_types]&.split(","))
 w.run


### PR DESCRIPTION
I bungled the option and failed to test it before pushing it up. 

Moved the split to the actual class instantiation, the default will still backup if there isn't anything there due to it being nil thanks to `&.`

cc @syncrou @slemrmartin 