### PR TITLE
[WIP] Persister autoscaler

### DIFF
--- a/bin/metrics_scaler
+++ b/bin/metrics_scaler
@@ -6,7 +6,9 @@ $:.push File.expand_path("../../lib", __FILE__)
 
 require 'optimist'
 args = Optimist.options do
-  opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics", :type => :integer, :default => 9394
+  opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics", :type => :integer, :default => (ENV['METRICS_PORT'] || 9394).to_i
+  opt :thanos_host, "Host of the Thanos metrics server", :type => :string, :default => ENV['THANOS_HOST']
+  opt :thanos_port, "Port of the Thanos metrics server", :type => :integer, :default => ENV['THANOS_PORT'].to_i
 end
 
 require "topological_inventory/orchestrator/application_metrics"
@@ -19,5 +21,5 @@ Signal.trap("TERM") do
   exit
 end
 
-w = TopologicalInventory::Orchestrator::MetricScaler.new
+w = TopologicalInventory::Orchestrator::MetricScaler.new("#{args[:thanos_host]}:#{args[:thanos_port]}")
 w.run

--- a/bin/metrics_scaler
+++ b/bin/metrics_scaler
@@ -9,6 +9,7 @@ args = Optimist.options do
   opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics", :type => :integer, :default => (ENV['METRICS_PORT'] || 9394).to_i
   opt :thanos_host, "Host of the Thanos metrics server", :type => :string, :default => ENV['THANOS_HOST']
   opt :thanos_port, "Port of the Thanos metrics server", :type => :integer, :default => ENV['THANOS_PORT'].to_i
+  opt :persister_promql_namespace, "Kubernetes namespace for persister's PromQL", :type => :integer, :default => ENV['PERSISTER_PROMQL_NAMESPACE']
 end
 
 require "topological_inventory/orchestrator/application_metrics"
@@ -21,5 +22,5 @@ Signal.trap("TERM") do
   exit
 end
 
-w = TopologicalInventory::Orchestrator::MetricScaler.new("#{args[:thanos_host]}:#{args[:thanos_port]}")
+w = TopologicalInventory::Orchestrator::MetricScaler.new("#{args[:thanos_host]}:#{args[:thanos_port]}", args[:persister_promql_namespace])
 w.run

--- a/lib/topological_inventory/orchestrator/metric_scaler.rb
+++ b/lib/topological_inventory/orchestrator/metric_scaler.rb
@@ -1,45 +1,52 @@
 require "manageiq-loggers"
+require "topological_inventory/orchestrator/object_manager"
+require "topological_inventory/orchestrator/metric_scaler/watcher"
+require "topological_inventory/orchestrator/metric_scaler/persister_watcher"
 
 module TopologicalInventory
   module Orchestrator
     class MetricScaler
       attr_reader :logger
 
-      def initialize(logger = nil)
-        require "topological_inventory/orchestrator/metric_scaler/watcher"
+      def initialize(thanos_hostname, logger = nil)
         @logger = logger || ManageIQ::Loggers::CloudWatch.new
+        @thanos_hostname = thanos_hostname
         @cache  = {}
       end
 
       def run
+        logger.info("#{self.class.name}##{__method__} Starting...")
         loop do
           run_once
 
           sleep 10
         end
+        logger.info("#{self.class.name}##{__method__} Complete")
       end
 
       def run_once
-        logger.info("#{self.class.name}##{__method__} Starting...")
         dc_names = object_manager.get_deployment_configs("metric_scaler_enabled=true").collect { |dc| dc.metadata.name }
 
         # newly_configured
-        (dc_names - @cache.keys).each { |name| @cache[name] = Watcher.new(name, logger).tap(&:start) }
+        (dc_names - @cache.keys).each { |name| @cache[name] = watcher_by_name(name).tap(&:start) }
         # no_longer_configured
         (@cache.keys - dc_names).each { |name| @cache.delete(name).stop }
         # currently configured
-        dc_names.each                 { |name| @cache[name].scale_to_desired_replicas }
-
-        logger.info("#{self.class.name}##{__method__} Complete")
+        dc_names.each                 { |name| @cache[name].scale_to_desired_replicas if @cache[name].scaling_allowed? }
       end
 
       private
 
-      def object_manager
-        @object_manager ||= begin
-          require "topological_inventory/orchestrator/object_manager"
-          ObjectManager.new
+      def watcher_by_name(dc_name)
+        if dc_name.include?('persister')
+          PersisterWatcher.new(dc_name, @thanos_hostname, logger)
+        else
+          Watcher.new(dc_name, logger)
         end
+      end
+
+      def object_manager
+        @object_manager ||= ObjectManager.new
       end
     end
   end

--- a/lib/topological_inventory/orchestrator/metric_scaler.rb
+++ b/lib/topological_inventory/orchestrator/metric_scaler.rb
@@ -8,9 +8,10 @@ module TopologicalInventory
     class MetricScaler
       attr_reader :logger
 
-      def initialize(thanos_hostname, logger = nil)
+      def initialize(thanos_hostname, persister_promql_namespace, logger = nil)
         @logger = logger || ManageIQ::Loggers::CloudWatch.new
         @thanos_hostname = thanos_hostname
+        @persister_promql_namespace = persister_promql_namespace
         @cache  = {}
       end
 
@@ -38,8 +39,8 @@ module TopologicalInventory
       private
 
       def watcher_by_name(dc_name)
-        if dc_name.include?('persister')
-          PersisterWatcher.new(dc_name, @thanos_hostname, logger)
+        if dc_name.include?('topological-inventory-persister')
+          PersisterWatcher.new(dc_name, @thanos_hostname, @persister_promql_namespace, logger)
         else
           Watcher.new(dc_name, logger)
         end

--- a/lib/topological_inventory/orchestrator/metric_scaler/persister_watcher.rb
+++ b/lib/topological_inventory/orchestrator/metric_scaler/persister_watcher.rb
@@ -1,0 +1,107 @@
+require "topological_inventory/orchestrator/metric_scaler/watcher"
+require "pry-byebug"
+
+module TopologicalInventory
+  module Orchestrator
+    class MetricScaler
+      class PersisterWatcher < Watcher
+        METRICS_STEP           = 30
+        METRICS_CHECK_INTERVAL = 150
+        METRICS_RANGE          = 300
+
+        def initialize(deployment_config_name, thanos_hostname, logger)
+          super(deployment_config_name, logger)
+          @thanos_hostname = thanos_hostname
+          @scaling_allowed.value = false
+        end
+
+        def configured?
+          true
+        end
+
+        def configure
+          @deployment_config  = object_manager.get_deployment_config(deployment_config_name)
+          @min_replicas       = 1
+          @max_replicas       = 10
+          @scale_threshold    = 25 # threshold for scaling
+          @target_usage       = 50 # target queue depth
+        end
+
+        def start
+          @thread = Thread.new do
+            logger.info("Watcher thread for #{deployment_config_name} starting")
+            until finished?
+              download_metrics.each do |time_value_pair|
+                metrics << time_value_pair[1]
+              end
+
+              @scaling_allowed.value = true
+
+              sleep METRICS_CHECK_INTERVAL
+            end
+            logger.info("Watcher thread for #{deployment_config_name} stopping")
+          end
+        end
+
+        def download_metrics
+          full_url = File.join(thanos_api_url, promql_query)
+          response = RestClient.get(full_url, {:accept => :json})
+
+          body = JSON.parse(response.body)
+          raise response.body unless body['status'] == 'success'
+
+          metrics = body.dig('data', 'result').to_a.first
+          if metrics.blank?
+            logger.warn("PersisterWatcher: Empty result from Thanos received")
+          end
+          metrics.to_a
+        rescue RestClient::BadRequest => e
+          logger.error("PersisterWatcher: Bad request: #{e.response.body}")
+          []
+        rescue RestClient::ExceptionWithResponse => e
+          logger.error("PersisterWatcher: RestClient error: #{e.message}")
+          []
+        rescue => e
+          logger.error("PersisterWatcher: #{e.message}\n#{e.backtrace.join("\n")}")
+          []
+        end
+
+        def scale_to_desired_replicas
+          super
+          @scaling_allowed.value = false
+        end
+
+        private
+
+        def desired_replicas
+          avg_consumer_lag = metrics.average
+          return deployment_config.spec.replicas if avg_consumer_lag.to_i.zero? # Thanos doesn't have data
+
+          super
+        end
+
+        def max_metrics_count
+          METRICS_RANGE / METRICS_STEP
+        end
+
+        def thanos_api_url
+          @thanos_hostname = "http://#{@thanos_hostname}" unless @thanos_hostname =~ %r{\Ahttps?:\/\/}
+          uri = URI(@thanos_hostname)
+          uri.path = default_api_path if uri.path.blank?
+          uri.to_s
+        end
+
+        def default_api_path
+          "/api/v1".freeze
+        end
+
+        def promql_query
+          query = "query_range?query=sum(kafka_consumergroup_group_lag{topic=~'platform.topological-inventory.persister'}) by (group, topic)"
+          query += "&start=#{(Time.now.utc - METRICS_RANGE).strftime("%Y-%m-%dT%H:%M:%S.%LZ")}" # RFC 3339
+          query += "&end=#{(Time.now.utc).strftime("%Y-%m-%dT%H:%M:%S.%LZ")}" # RFC 3339
+          query += "&step=#{METRICS_STEP.to_f}"
+        end
+      end
+    end
+  end
+end

--- a/spec/metric_scaler_spec.rb
+++ b/spec/metric_scaler_spec.rb
@@ -3,7 +3,7 @@ require File.join(__dir__, "../lib/topological_inventory/orchestrator/metric_sca
 require File.join(__dir__, "../lib/topological_inventory/orchestrator/object_manager")
 
 describe TopologicalInventory::Orchestrator::MetricScaler do
-  let(:instance) { described_class.new(logger) }
+  let(:instance) { described_class.new(nil, logger) }
   let(:logger)   { Logger.new(StringIO.new).tap { |logger| allow(logger).to receive(:info) } }
 
   it "skips deployment configs that aren't fully configured" do

--- a/spec/metric_scaler_spec.rb
+++ b/spec/metric_scaler_spec.rb
@@ -3,7 +3,7 @@ require File.join(__dir__, "../lib/topological_inventory/orchestrator/metric_sca
 require File.join(__dir__, "../lib/topological_inventory/orchestrator/object_manager")
 
 describe TopologicalInventory::Orchestrator::MetricScaler do
-  let(:instance) { described_class.new(nil, logger) }
+  let(:instance) { described_class.new(nil, nil, logger) }
   let(:logger)   { Logger.new(StringIO.new).tap { |logger| allow(logger).to receive(:info) } }
 
   it "skips deployment configs that aren't fully configured" do

--- a/spec/topological_inventory/orchestrator/metric_scaler/persister_watcher_spec.rb
+++ b/spec/topological_inventory/orchestrator/metric_scaler/persister_watcher_spec.rb
@@ -1,0 +1,114 @@
+require "topological_inventory/orchestrator/metric_scaler/persister_watcher"
+require "topological_inventory/orchestrator/test_models/object_manager"
+
+describe TopologicalInventory::Orchestrator::MetricScaler::PersisterWatcher do
+  let(:logger) { Logger.new(StringIO.new).tap { |logger| allow(logger).to receive(:info) } }
+
+  let(:deployment_config_name) { 'topological-inventory-persister' }
+  let(:deployment)     { double("deployment", :metadata => double("metadata", :name => deployment_config_name), :spec => double("spec", :replicas => replicas)) }
+  let(:metrics)        { watcher.send(:metrics) }
+  let(:object_manager) { double("TopologicalInventory::Orchestrator::ObjectManager", :get_deployment_configs => [deployment], :get_deployment_config => deployment) }
+  let(:replicas)       { 3 }
+  let(:watcher)        { described_class.new(deployment.metadata.name, 'thanos.example.com', 'platform-mq-ci', logger) }
+
+  before { allow(TopologicalInventory::Orchestrator::ObjectManager).to receive(:new).and_return(object_manager) }
+
+  context "downloading metrics" do
+    before do
+      stub_const("#{described_class}::METRICS_CHECK_INTERVAL", 0)
+
+      # Allow just a single run
+      allow(watcher).to receive(:finished?) do
+        finished = watcher.instance_variable_get(:@finished)
+        old_value = finished.value
+        finished.value = true
+        old_value
+      end
+    end
+
+    it "fills metrics array when successful" do
+      downloaded = 10.times.collect { |i| [Time.now.to_i, 10]}
+      allow(watcher).to receive(:download_metrics).and_return(downloaded)
+
+      watcher.start
+      watcher.thread.join
+
+      expect(metrics.values).to eq(Array.new(10, 10))
+    end
+
+    it "allows scaling run only when successful" do
+      downloaded = 5.times.collect { |i| [Time.now.to_i, 10]}
+      allow(watcher).to receive(:download_metrics).and_return(downloaded)
+
+      watcher.start
+      watcher.thread.join
+
+      expect(metrics.average).to eq(10)
+      expect(watcher.scaling_allowed?).to be_truthy
+    end
+
+    it "doesn't allow scaling run when no data collected" do
+      allow(watcher).to receive(:download_metrics).and_return([])
+
+      watcher.start
+      watcher.thread.join
+
+      expect(watcher.scaling_allowed?).to be_falsey
+    end
+
+    it "doesn't allow scaling run when zero data collected" do
+      downloaded = 10.times.collect { |i| [Time.now.to_i, 0]}
+      allow(watcher).to receive(:download_metrics).and_return(downloaded)
+
+      watcher.start
+      watcher.thread.join
+
+      expect(metrics.values).to eq(Array.new(10, 0))
+      expect(watcher.scaling_allowed?).to be_falsey
+    end
+  end
+
+  context "scaling" do
+    before do
+      watcher.instance_variable_set(:@target_usage, 10)
+      watcher.instance_variable_set(:@scale_threshold, 5)
+    end
+
+    it "doesn't scale if no data available" do
+      expect(watcher.send(:desired_replicas)).to eq(replicas)
+
+      10.times { metrics << 0 }
+      expect(watcher.send(:desired_replicas)).to eq(replicas)
+    end
+
+    it "scales up when kafka consumer lag is greater than threshold" do
+      10.times { metrics << 16 }
+
+      expect(watcher.send(:desired_replicas)).to eq(replicas + 1)
+    end
+
+    it "doesn't scale up when limit reached" do
+      allow(deployment.spec).to receive(:replicas).and_return(10)
+
+      10.times { metrics << 16 }
+      expect(watcher.send(:desired_replicas)).to eq(10)
+    end
+
+    it "scales down when kafka consumer lag is lower than threshold" do
+      10.times { metrics << 4 }
+      expect(watcher.send(:desired_replicas)).to eq(replicas - 1)
+    end
+
+    it "doesn't scale below 1" do
+      allow(deployment.spec).to receive(:replicas).and_return(1)
+
+      10.times { metrics << 1 }
+      expect(watcher.send(:desired_replicas)).to eq(1)
+    end
+
+    it "doesn't scale when kafka consumer lag is in limits" do
+      10.times { metrics << 11 }
+      expect(watcher.send(:desired_replicas)).to eq(replicas)
+    end
+  end
+end


### PR DESCRIPTION
Persister autoscaler based on `kafka_consumergroup_group_lag`
http://thanos-query-mnm-ci.5a9f.insights-dev.openshiftapps.com/graph?g0.range_input=1d&g0.max_source_resolution=0s&g0.expr=sum(kafka_consumergroup_group_lag%7Btopic%3D~%27platform.topological-inventory.persister%27%7D)%20by%20(group%2C%20topic)&g0.tab=0

It makes avg from last 300 seconds (step 30s), checking once per 150 seconds.
It scales down if the lag < 25, scales up if the lag is > 75 **[has to be tested]**

Minimum pods = 1, maximum pods = 10.