### PR TITLE
Ruby version update for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.4.5
+- 2.5.7
+- 2.6.5
 before_install:
 - gem install bundler
 before_script:


### PR DESCRIPTION
Upgrading the ruby version from 2.4.5 to 2.5.7 and adding the 2.6.5 version for travis testing.