### PR TITLE
 Gemfile update (Hakiri warnings)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem "activesupport",        "~> 5.2.4", ">= 5.2.4.2"
+gem "activesupport",        '~> 5.2.4.3'
 gem "cloudwatchlogger",     "~> 0.2"
 gem "config",               "~> 1.7.2"
 gem "http",                 "~> 4.1.1"
@@ -16,6 +16,6 @@ gem "prometheus_exporter",  "~> 0.4.5"
 gem "rest-client",          "~> 2.0"
 
 group :test do
-  gem "rake",               "~> 10.0"
+  gem "rake",               ">= 12.3.3"
   gem "rspec",              "~> 3.8"
 end


### PR DESCRIPTION
Hakiri warnings CVE-2020-8130 and CVE-2020-8165.

Updating the rake and activesupport gem versions.