### PR TITLE
Add metrics on failure to hit prometheus

### DIFF
--- a/bin/metrics_scaler
+++ b/bin/metrics_scaler
@@ -21,5 +21,5 @@ Signal.trap("TERM") do
   exit
 end
 
-w = TopologicalInventory::Orchestrator::MetricScaler.new("#{args[:prometheus_host]}:#{args[:prometheus_port]}")
+w = TopologicalInventory::Orchestrator::MetricScaler.new(metrics, "#{args[:prometheus_host]}:#{args[:prometheus_port]}")
 w.run

--- a/lib/topological_inventory/orchestrator/application_metrics.rb
+++ b/lib/topological_inventory/orchestrator/application_metrics.rb
@@ -18,6 +18,10 @@ module TopologicalInventory
         @server&.stop
       end
 
+      def record_metric_scaler_error
+        @metric_scaler_error&.observe(1)
+      end
+
       private
 
       def configure_server(port)
@@ -30,6 +34,9 @@ module TopologicalInventory
       def configure_metrics
         PrometheusExporter::Instrumentation::Process.start
         PrometheusExporter::Metric::Base.default_prefix = "topological_inventory_orchestrator_"
+
+        @metric_scaler_error = PrometheusExporter::Metric::Counter.new("metric_scaler_error", "total number of times the metric_scaler has failed to hit prometheus")
+        @server.collector.register_metric(@metric_scaler_error)
       end
     end
   end

--- a/lib/topological_inventory/orchestrator/metric_scaler.rb
+++ b/lib/topological_inventory/orchestrator/metric_scaler.rb
@@ -8,7 +8,8 @@ module TopologicalInventory
     class MetricScaler
       attr_reader :logger
 
-      def initialize(prometheus_hostname, logger = nil)
+      def initialize(metrics, prometheus_hostname, logger = nil)
+        @metrics = metrics
         @logger = logger || ManageIQ::Loggers::CloudWatch.new
         @prometheus_hostname = prometheus_hostname
         @cache  = {}
@@ -41,7 +42,7 @@ module TopologicalInventory
         dc = object_manager.get_deployment_config(dc_name)
 
         if dc.metadata.annotations["metric_scaler_prometheus_query"]
-          PrometheusWatcher.new(dc, dc_name, @prometheus_hostname, logger)
+          PrometheusWatcher.new(@metrics, dc, dc_name, @prometheus_hostname, logger)
         else
           Watcher.new(dc, dc_name, logger)
         end

--- a/spec/metric_scaler_spec.rb
+++ b/spec/metric_scaler_spec.rb
@@ -3,7 +3,7 @@ require File.join(__dir__, "../lib/topological_inventory/orchestrator/metric_sca
 require File.join(__dir__, "../lib/topological_inventory/orchestrator/object_manager")
 
 describe TopologicalInventory::Orchestrator::MetricScaler do
-  let(:instance) { described_class.new(nil, logger) }
+  let(:instance) { described_class.new(nil, nil, logger) }
   let(:logger)   { Logger.new(StringIO.new).tap { |logger| allow(logger).to receive(:info) } }
 
   it "skips deployment configs that aren't fully configured" do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-973

This way we can alert if we are continually failing to get metrics in order to...scale based on prometheus metrics

\# TODO: 
- [ ] [e2e-deploy PR](https://github.com/RedHatInsights/e2e-deploy/pull/1892) to add alerting. This can go in before that though, that way it can expose the metrics without alerting on them.
