### PR TITLE
Add receptor_node to configmap settings from sources

### DIFF
--- a/lib/topological_inventory/orchestrator/config_map.rb
+++ b/lib/topological_inventory/orchestrator/config_map.rb
@@ -263,14 +263,16 @@ module TopologicalInventory
 
       def source_to_yaml(source)
         {
-          :source      => source['uid'],
-          :source_id   => source['id'],
-          :source_name => source['name'],
-          :scheme      => source.endpoint['scheme'],
-          :host        => source.endpoint['host'],
-          :port        => source.endpoint['port'],
-          :path        => source.endpoint['path'],
-          :digest      => source.digest
+          :source         => source['uid'],
+          :source_id      => source['id'],
+          :source_name    => source['name'],
+          :scheme         => source.endpoint['scheme'],
+          :host           => source.endpoint['host'],
+          :port           => source.endpoint['port'],
+          :path           => source.endpoint['path'],
+          :receptor_node  => source.endpoint['receptor_node'],
+          :account_number => source.tenant,
+          :digest         => source.digest
         }
       end
 

--- a/lib/topological_inventory/orchestrator/deployment_config.rb
+++ b/lib/topological_inventory/orchestrator/deployment_config.rb
@@ -94,11 +94,17 @@ module TopologicalInventory
 
       def container_env_values
         [
-          { :name => "INGRESS_API", :value => "http://#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"]}:#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_PORT"]}" },
-          { :name => "CONFIG", :value => 'custom'},
-          { :name => "CLOUD_WATCH_LOG_GROUP", :value => ENV["CLOUD_WATCH_LOG_GROUP"] },
-          { :name => "CW_AWS_ACCESS_KEY_ID", :valueFrom => { :secretKeyRef => { :name => 'cloudwatch', :key => 'CW_AWS_ACCESS_KEY_ID' }}},
-          { :name => "CW_AWS_SECRET_ACCESS_KEY", :valueFrom => { :secretKeyRef => { :name => 'cloudwatch', :key => 'CW_AWS_SECRET_ACCESS_KEY' }}},
+          {:name => "INGRESS_API", :value => "http://#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"]}:#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_PORT"]}"},
+          {:name => "CONFIG", :value => 'custom'},
+          {:name => "CLOUD_WATCH_LOG_GROUP", :value => ENV["CLOUD_WATCH_LOG_GROUP"]},
+          {:name => "CW_AWS_ACCESS_KEY_ID", :valueFrom => {:secretKeyRef => {:name => 'cloudwatch', :key => 'CW_AWS_ACCESS_KEY_ID'}}},
+          {:name => "CW_AWS_SECRET_ACCESS_KEY", :valueFrom => {:secretKeyRef => {:name => 'cloudwatch', :key => 'CW_AWS_SECRET_ACCESS_KEY'}}},
+          {:name => "QUEUE_HOST", :value => ENV["QUEUE_HOST"]},
+          {:name => "QUEUE_PORT", :value => ENV["QUEUE_PORT"]},
+          {:name => "RECEPTOR_CONTROLLER_HOST", :value => ENV["RECEPTOR_CONTROLLER_HOST"]},
+          {:name => "RECEPTOR_CONTROLLER_SCHEME", :value => ENV["RECEPTOR_CONTROLLER_SCHEME"]},
+          {:name => "RECEPTOR_CONTROLLER_PORT", :value => ENV["RECEPTOR_CONTROLLER_PORT"]},
+          {:name => "RECEPTOR_CONTROLLER_PSK", :valueFrom => {:secretKeyRef => {:name => 'receptor', :key => 'RECEPTOR_CONTROLLER_PSK'}}},
         ]
       end
 

--- a/lib/topological_inventory/orchestrator/source.rb
+++ b/lib/topological_inventory/orchestrator/source.rb
@@ -76,7 +76,7 @@ module TopologicalInventory
       def azure_tenant
         authentication.try(:[], "extra").try(:[], "azure").try(:[], "tenant_id")
       end
-      
+
       private
 
       def digest_values
@@ -98,6 +98,12 @@ module TopologicalInventory
         if source_type.azure?
           tenant_id = azure_tenant.to_s
           hash['secret']['tenant_id'] = tenant_id if tenant_id.present?
+        end
+
+        # Set the receptor fields if they are present.
+        if endpoint["receptor_node"].present?
+          hash["receptor_node"] = endpoint["receptor_node"]
+          hash["account_number"] = tenant
         end
         hash
       end

--- a/spec/config_map_spec.rb
+++ b/spec/config_map_spec.rb
@@ -6,8 +6,8 @@ describe TopologicalInventory::Orchestrator::ConfigMap do
 
   let(:object_manager) { double('object_manager') }
   let(:openshift_object) { double('openshift_object') }
-  let(:source) { TopologicalInventory::Orchestrator::Source.new({'id' => '1', 'uid' => 'source-1', 'name' => 'Source 1'}, nil, nil, nil, from_sources_api: true) }
-  let(:source2) { TopologicalInventory::Orchestrator::Source.new({'id' => '2', 'uid' => 'source-2', 'name' => 'Source 2'}, nil, nil, nil, from_sources_api: true) }
+  let(:source) { TopologicalInventory::Orchestrator::Source.new({'id' => '1', 'uid' => 'source-1', 'name' => 'Source 1'}, "tid", nil, nil, :from_sources_api => true) }
+  let(:source2) { TopologicalInventory::Orchestrator::Source.new({'id' => '2', 'uid' => 'source-2', 'name' => 'Source 2'}, "tid", nil, nil, :from_sources_api => true) }
   let(:source_type) { TopologicalInventory::Orchestrator::SourceType.new(source_types_data[:openshift]) }
   let(:secret) { double('secret') }
   let(:deployment_config) { double('deployment_config') }
@@ -60,8 +60,8 @@ describe TopologicalInventory::Orchestrator::ConfigMap do
 
   context "add or remove" do
     let(:config_map_data) { OpenStruct.new }
-    let(:endpoint1) { {'scheme' => 'https', 'host' => 'one.example.com', 'port' => 443, 'path' => nil} }
-    let(:endpoint2) { {'scheme' => 'https', 'host' => 'two.example.com', 'port' => 443, 'path' => '/api'} }
+    let(:endpoint1) { {'scheme' => 'https', 'host' => 'one.example.com', 'port' => 443, 'path' => nil, 'receptor_node' => "a-node-somewhere"} }
+    let(:endpoint2) { {'scheme' => 'https', 'host' => 'two.example.com', 'port' => 443, 'path' => '/api', 'receptor_node' => nil} }
     before do
       allow(openshift_object).to receive(:data).and_return(config_map_data)
     end
@@ -98,8 +98,8 @@ describe TopologicalInventory::Orchestrator::ConfigMap do
         # Compare it with endpoints and source uids
         loaded_data = YAML.load(config_map_data['custom.yml'])
         expected_data = [
-          endpoint1.transform_keys!(&:to_sym).merge(:source => source['uid'], :source_id => source['id'], :source_name => source['name'], :digest => digest),
-          endpoint2.transform_keys!(&:to_sym).merge(:source => source2['uid'], :source_id => source2['id'], :source_name => source2['name'], :digest => digest2)
+          endpoint1.transform_keys!(&:to_sym).merge(:source => source['uid'], :source_id => source['id'], :source_name => source['name'], :digest => digest, :account_number => "tid"),
+          endpoint2.transform_keys!(&:to_sym).merge(:source => source2['uid'], :source_id => source2['id'], :source_name => source2['name'], :digest => digest2, :account_number => "tid")
         ]
         expect(loaded_data[:sources]).to eq(expected_data)
       end
@@ -198,7 +198,7 @@ describe TopologicalInventory::Orchestrator::ConfigMap do
         # Compare it with endpoints and source uids
         loaded_data = YAML.load(config_map_data['custom.yml'])
         expected_data = [
-          endpoint2.transform_keys!(&:to_sym).merge(:source => source2['uid'], :source_id => source2['id'], :source_name => source2['name'], :digest => digest2)
+          endpoint2.transform_keys!(&:to_sym).merge(:source => source2['uid'], :source_id => source2['id'], :source_name => source2['name'], :digest => digest2, :account_number => "tid")
         ]
         expect(loaded_data[:sources]).to eq(expected_data)
         expect(config_map.sources).to eq([source2])

--- a/spec/targeted_update_spec.rb
+++ b/spec/targeted_update_spec.rb
@@ -205,8 +205,8 @@ describe TopologicalInventory::Orchestrator::TargetedUpdate do
 
     it "updates sources and keeps others unchanged" do
       changed_source = sources_data[:openshift][@id1].merge('name' => 'Changed!')
-      changed_endpoint = endpoints[@id3].merge('host' => 'my-testing-url.com')
-      changed_digest = 'eb5c76b3094e1f3691e6c710403acdcf17c92e04'
+      changed_endpoint = endpoints[@id3].merge('host' => 'my-testing-url.com', 'receptor_node' => 'a-node')
+      changed_digest = '54b460e847025e028bd9ebe6061ae94360853d08'
 
       subject.add_target('Source', 'update', changed_source)
       subject.add_target('Endpoint', 'update', changed_endpoint)


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-990

This PR adds the `receptor_node` setting to the configmap created by orchestrator (if present). The collector will still have to be updated in order to take advantage of it, but at least with this we can always assume it is there. 

*Depends on:*
- [x] https://github.com/RedHatInsights/e2e-deploy/pull/1916

\# TODO: 
- [x] Add to configmap
- [x] Add configmap setting to digest
- [x] specs
- [x] add setting of queue host/receptor information via env vars

cc @syncrou @slemrmartin 