### PR TITLE
Update DeploymentConfig resource to pull image definition from running operations workers

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -8,7 +8,7 @@ require "topological_inventory-orchestrator"
 require "irb"
 
 def default_worker
-  TopologicalInventory::Orchestrator::Worker.new(collector_image_tag: ENV["IMAGE_TAG"], sources_api: ENV["SOURCES_API"], topology_api: ENV["TOPOLOGICAL_INVENTORY_API"])
+  TopologicalInventory::Orchestrator::Worker.new(sources_api: ENV["SOURCES_API"], topology_api: ENV["TOPOLOGICAL_INVENTORY_API"])
 end
 
 IRB.start

--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -8,7 +8,6 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 def parse_args
   require 'optimist'
   opts = Optimist.options do
-    opt :collector_image_tag, "Image tag to use for the collector images, e.g. latest, stable", :type => :string, :default => ENV["IMAGE_TAG"], :required => ENV["IMAGE_TAG"].nil?
     opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics", :type => :integer, :default => 9394
     opt :sources_api, "URL to the sources service, e.g. http://localhost:3000/api/v1.0", :type => :string,
         :default => ENV["SOURCES_API"], :required => ENV["SOURCES_API"].nil?
@@ -34,5 +33,10 @@ Signal.trap("TERM") do
   exit
 end
 
-w = TopologicalInventory::Orchestrator::Worker.new(:collector_image_tag => args[:collector_image_tag], :sources_api => args[:sources_api], :topology_api => args[:topology_api], :config_name => args[:config], :source_types => args[:source_types]&.split(","))
+w = TopologicalInventory::Orchestrator::Worker.new(
+  :sources_api  => args[:sources_api],
+  :topology_api => args[:topology_api],
+  :config_name  => args[:config],
+  :source_types => args[:source_types]&.split(",")
+)
 w.run

--- a/lib/topological_inventory/orchestrator/config_map.rb
+++ b/lib/topological_inventory/orchestrator/config_map.rb
@@ -68,7 +68,7 @@ module TopologicalInventory
           source = sources_by_digest[digest]
           if source.nil?
             # This source is not in API, will be deleted from openshift
-            source = Source.new({}, nil, source_type, nil, :from_sources_api => false)
+            source = Source.new({}, nil, source_type, :from_sources_api => false)
             source.digest = digest
             sources_by_digest[digest] = source
             logger.debug("Assoc Map (#{uid}) -> Source (digest #{digest}) not found")
@@ -272,6 +272,7 @@ module TopologicalInventory
           :path           => source.endpoint['path'],
           :receptor_node  => source.endpoint['receptor_node'],
           :account_number => source.tenant,
+          :image_tag_sha  => source.source_type['collector_image'].split(":").last,
           :digest         => source.digest
         }
       end

--- a/lib/topological_inventory/orchestrator/deployment_config.rb
+++ b/lib/topological_inventory/orchestrator/deployment_config.rb
@@ -26,10 +26,9 @@ module TopologicalInventory
           logger.warn("Failed to create deployment config, no existing source associated")
           return
         end
-        image = related_source.collector_definition["image"]
 
         logger.info("Creating DeploymentConfig #{self}")
-        object_manager.create_deployment_config(name, ENV["IMAGE_NAMESPACE"], image) do |dc|
+        object_manager.create_deployment_config(name, config_map.source_type["collector_image"]) do |dc|
           dc[:metadata][:labels][LABEL_UNIQUE] = uid
           dc[:metadata][:labels][LABEL_COMMON] = ::Settings.labels.version.to_s
           dc[:metadata][:labels][ConfigMap::LABEL_SOURCE_TYPE] = config_map.source_type['name'] if config_map.source_type.present?

--- a/lib/topological_inventory/orchestrator/source.rb
+++ b/lib/topological_inventory/orchestrator/source.rb
@@ -15,12 +15,11 @@ module TopologicalInventory
         name
       end
 
-      def initialize(attributes, tenant, source_type, collector_definition, from_sources_api:)
+      def initialize(attributes, tenant, source_type, from_sources_api: nil)
         super(attributes)
 
         self.tenant = tenant
         self.source_type = source_type
-        self.collector_definition = collector_definition
         self.from_sources_api = from_sources_api
 
         self.endpoint = nil
@@ -85,8 +84,7 @@ module TopologicalInventory
           "endpoint_path"   => endpoint["path"],
           "endpoint_port"   => endpoint["port"].to_s,
           "endpoint_scheme" => endpoint["scheme"],
-          "image"           => collector_definition["image"],
-          "image_namespace" => ENV["IMAGE_NAMESPACE"],
+          "image"           => source_type["collector_image"],
           "source_id"       => attributes["id"],
           "source_uid"      => attributes["uid"],
           "secret"          => {

--- a/lib/topological_inventory/orchestrator/source_type.rb
+++ b/lib/topological_inventory/orchestrator/source_type.rb
@@ -28,12 +28,6 @@ module TopologicalInventory
         @sources_per_collector
       end
 
-      def collector_definition(collector_image_tag = 'latest')
-        if supported_source_type?
-          { "image" => "topological-inventory-#{attributes['name']}:#{collector_image_tag}" }
-        end
-      end
-
       def supported_source_type?
         attributes['name'].present? && self[:enabled?]
       end

--- a/lib/topological_inventory/orchestrator/targeted_update/api_load_helpers.rb
+++ b/lib/topological_inventory/orchestrator/targeted_update/api_load_helpers.rb
@@ -73,7 +73,7 @@ module TopologicalInventory
         def hash_to_api_object(data, dest_model = nil)
           case dest_model
           when :source_type then SourceType.new(data)
-          when :source then Source.new(data, data['tenant'], nil, nil, :from_sources_api => true)
+          when :source then Source.new(data, data['tenant'], nil, :from_sources_api => true)
           else ApiObject.new(data)
           end
         end

--- a/spec/helpers/mock_data.rb
+++ b/spec/helpers/mock_data.rb
@@ -44,10 +44,10 @@ module MockData
 
   def source_types_data
     {
-      :openshift => {"id" => "1", "name" => "openshift", "product_name" => "OpenShift", "vendor" => "Red Hat"},
-      :amazon    => {"id" => "2", "name" => "amazon", "product_name" => "Amazon AWS", "vendor" => "Amazon"},
-      :azure     => {"id" => "3", "name" => "azure", "product_name" => "Azure", "vendor" => "Azure"},
-      :mock      => {"id" => "4", "name" => "mock", "product_name" => "Azure", "vendor" => "Azure"}
+      :openshift => {"id" => "1", "name" => "openshift", "product_name" => "OpenShift", "vendor" => "Red Hat", "collector_image" => "abc123"},
+      :amazon    => {"id" => "2", "name" => "amazon", "product_name" => "Amazon AWS", "vendor" => "Amazon", "collector_image" => "abc123"},
+      :azure     => {"id" => "3", "name" => "azure", "product_name" => "Azure", "vendor" => "Azure", "collector_image" => "abc123"},
+      :mock      => {"id" => "4", "name" => "mock", "product_name" => "Azure", "vendor" => "Azure", "collector_image" => "abc123"},
     }
   end
 
@@ -205,19 +205,19 @@ module MockData
   # Values are for source + endpoint + credentials of the same ID
   def digests_data
     {
-      '1'  => '1d9e34af4e70ad44a47c74aebe0cf74d3980c887',
+      '1'  => '7a8a3dad389031160f79817c14bb5f3adf058335',
       '2'  => '8d4fc3e19f141135ca59f0ba5d9e8b634f04840e',
-      '3'  => 'ee53859fd0b58430b75907894600b77755674b01',
-      '4'  => '98a148ffce1fb8c6875f4b6dc8bd2935b0bb868a',
-      '5'  => '3acba9bf43755682f00942ab56cbf995cd75a702',
-      '6'  => '741fc03f04725dcdda91168ae21750a0b7352ce4',
-      '7'  => '9e48b19ce700bf9535de5b99737c7467965d0b5e',
+      '3'  => '88f879b8aa22eb340019449955accdca62886f64',
+      '4'  => 'dba9f7cc5b15cc2eee74a288e6c04431d2f5e509',
+      '5'  => 'febf0d5b94e4dd2cd23f3a9cd515641885a50980',
+      '6'  => '2628bf51107c4c5cd581179df5d1148821f8a7a8',
+      '7'  => '83f929fdce5dfe931f9ccc6af49e2cfd436740f4',
       '8'  => '5f9e781563ab48e7a67ec4500321b1ebe553f3fc',
       '9'  => '8b14bf8dfa2bc7d74443cd9c4a0d836f1341becb',
       '10' => '5442273b216f7c843de10acc57c33638f7848f74',
       '11' => '3871068443e406fbff7ad6f91bd395bf9482a259',
       '12' => '9e52c47b63dd968ba2349779a86986eff2f2b860',
-      '13' => '579824266004c51aedf3237ad262a493c9c5bbe6'
+      '13' => '658ba6008127dc4e61eb5bbe70ec69be5524b845'
     }
   end
 

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -1,12 +1,9 @@
 describe TopologicalInventory::Orchestrator::Source do
   include MockData
 
-  let(:collector_definition) { { "image" => "topological-inventory-openshift:latest" } }
-
   before do
     @source = described_class.new(sources_data[:openshift]["1"], nil,
-                                  double, collector_definition,
-                                  :from_sources_api => true)
+                                  double, :from_sources_api => true)
   end
 
   context "#add_to_openshift" do

--- a/spec/targeted_update_spec.rb
+++ b/spec/targeted_update_spec.rb
@@ -9,15 +9,9 @@ describe TopologicalInventory::Orchestrator::TargetedUpdate do
   let(:application_types_response) { list(application_types_data) }
   let(:sources_by_ids) { sources_data.values.reduce({}, :merge) } # Merge array of hashes)
 
-  around do |e|
-    ENV["IMAGE_NAMESPACE"] = "buildfactory"
-    e.run
-    ENV.delete("IMAGE_NAMESPACE")
-  end
-
   let(:kube_client) { TopologicalInventory::Orchestrator::TestModels::KubeClient.new }
   let(:object_manager) { TopologicalInventory::Orchestrator::TestModels::ObjectManager.new(kube_client) }
-  let(:worker) { TopologicalInventory::Orchestrator::Worker.new(:collector_image_tag => "dev", :sources_api => sources_api, :topology_api => topology_api) }
+  let(:worker) { TopologicalInventory::Orchestrator::Worker.new(:sources_api => sources_api, :topology_api => topology_api) }
 
   subject do
     allow(described_class).to receive(:path_to_config).and_return(File.expand_path("../config", File.dirname(__FILE__)))
@@ -206,7 +200,7 @@ describe TopologicalInventory::Orchestrator::TargetedUpdate do
     it "updates sources and keeps others unchanged" do
       changed_source = sources_data[:openshift][@id1].merge('name' => 'Changed!')
       changed_endpoint = endpoints[@id3].merge('host' => 'my-testing-url.com', 'receptor_node' => 'a-node')
-      changed_digest = '54b460e847025e028bd9ebe6061ae94360853d08'
+      changed_digest = '42193e0216f5442f009da367fc0f4140a6b38eed'
 
       subject.add_target('Source', 'update', changed_source)
       subject.add_target('Endpoint', 'update', changed_endpoint)

--- a/spec/topological_inventory/orchestrator/object_manager_spec.rb
+++ b/spec/topological_inventory/orchestrator/object_manager_spec.rb
@@ -10,20 +10,21 @@ describe TopologicalInventory::Orchestrator::ObjectManager do
     before do
       allow(instance).to receive(:kube_connection).and_return(kube_client)
       allow(kube_client).to receive(:get_resource_quota).with("compute-resources-non-terminating", nil).and_return(quota)
+      allow(instance).to receive(:get_collector_image).with("ansible-tower").and_return("quay.io/ansible-tower:abcdefg")
     end
 
     it "quota allows" do
       expect(instance).to receive(:connection).and_return(kube_client)
       expect(kube_client).to receive(:create_deployment_config)
 
-      instance.create_deployment_config("test_name", "test_namespace", "test_image")
+      instance.create_deployment_config("test_name", "ansible-tower")
     end
 
     it "exceeds cpu limit" do
       expect(kube_client).not_to receive(:create_deployment_config)
 
       expect do
-        instance.create_deployment_config("test_name", "test_namespace", "test_image") do |deployment|
+        instance.create_deployment_config("test_name", "ansible-tower") do |deployment|
           deployment[:spec][:template][:spec][:containers].first[:resources][:limits][:cpu] = "7000m"
         end
       end.to raise_error(TopologicalInventory::Orchestrator::ObjectManager::QuotaCpuLimitExceeded)
@@ -33,7 +34,7 @@ describe TopologicalInventory::Orchestrator::ObjectManager do
       expect(kube_client).not_to receive(:create_deployment_config)
 
       expect do
-        instance.create_deployment_config("test_name", "test_namespace", "test_image") do |deployment|
+        instance.create_deployment_config("test_name", "ansible-tower") do |deployment|
           deployment[:spec][:template][:spec][:containers].first[:resources][:requests][:cpu] = "3000m"
         end
       end.to raise_error(TopologicalInventory::Orchestrator::ObjectManager::QuotaCpuRequestExceeded)
@@ -43,7 +44,7 @@ describe TopologicalInventory::Orchestrator::ObjectManager do
       expect(kube_client).not_to receive(:create_deployment_config)
 
       expect do
-        instance.create_deployment_config("test_name", "test_namespace", "test_image") do |deployment|
+        instance.create_deployment_config("test_name", "ansible-tower") do |deployment|
           deployment[:spec][:template][:spec][:containers].first[:resources][:limits][:memory] = "4000Mi"
         end
       end.to raise_error(TopologicalInventory::Orchestrator::ObjectManager::QuotaMemoryLimitExceeded)
@@ -53,7 +54,7 @@ describe TopologicalInventory::Orchestrator::ObjectManager do
       expect(kube_client).not_to receive(:create_deployment_config)
 
       expect do
-        instance.create_deployment_config("test_name", "test_namespace", "test_image") do |deployment|
+        instance.create_deployment_config("test_name", "ansible-tower") do |deployment|
           deployment[:spec][:template][:spec][:containers].first[:resources][:requests][:memory] = "3000Mi"
         end
       end.to raise_error(TopologicalInventory::Orchestrator::ObjectManager::QuotaMemoryRequestExceeded)

--- a/spec/topological_inventory/orchestrator/test_models/kube_client.rb
+++ b/spec/topological_inventory/orchestrator/test_models/kube_client.rb
@@ -7,7 +7,8 @@ module TopologicalInventory
       class KubeClient
         attr_accessor :config_maps, :deployment_configs,
                       :secrets, :endpoints,
-                      :replication_controllers
+                      :replication_controllers,
+                      :pods
         # {
         #   name => [RecursiveOpenStruct*]
         # }*
@@ -17,6 +18,7 @@ module TopologicalInventory
           self.secrets = {}
           self.endpoints = {}
           self.replication_controllers = {}
+          self.pods = {}
         end
 
         def get_config_maps(label_selector:, namespace:)
@@ -80,6 +82,10 @@ module TopologicalInventory
 
         def delete_secret(name, _namespace)
           secrets.delete(name)
+        end
+
+        def get_pods(_namespace:, label_selector:)
+          find_by_label(pods, label_selector)
         end
 
         private

--- a/spec/topological_inventory/orchestrator/test_models/object_manager.rb
+++ b/spec/topological_inventory/orchestrator/test_models/object_manager.rb
@@ -23,6 +23,10 @@ module TopologicalInventory
         def check_deployment_config_quota(definition)
           # Noop
         end
+
+        def get_collector_image(_name)
+          "quay.io/openshift:abc123"
+        end
       end
     end
   end

--- a/spec/worker_black_box_spec.rb
+++ b/spec/worker_black_box_spec.rb
@@ -1,12 +1,6 @@
 describe TopologicalInventory::Orchestrator::Worker do
   include Functions
 
-  around do |e|
-    ENV["IMAGE_NAMESPACE"] = "buildfactory"
-    e.run
-    ENV.delete("IMAGE_NAMESPACE")
-  end
-
   let(:kube_client) { TopologicalInventory::Orchestrator::TestModels::KubeClient.new }
   let(:object_manager) { TopologicalInventory::Orchestrator::TestModels::ObjectManager.new(kube_client) }
 
@@ -18,7 +12,7 @@ describe TopologicalInventory::Orchestrator::Worker do
 
   subject do
     allow(described_class).to receive(:path_to_config).and_return(File.expand_path("../config", File.dirname(__FILE__)))
-    described_class.new(:collector_image_tag => "dev", :sources_api => sources_api, :topology_api => topology_api)
+    described_class.new(:sources_api => sources_api, :topology_api => topology_api)
   end
 
   before do

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,12 +1,6 @@
 describe TopologicalInventory::Orchestrator::Worker do
   include Functions
 
-  around do |e|
-    ENV["IMAGE_NAMESPACE"] = "buildfactory"
-    e.run
-    ENV.delete("IMAGE_NAMESPACE")
-  end
-
   let(:kube_client) { TopologicalInventory::Orchestrator::TestModels::KubeClient.new }
   let(:object_manager) { TopologicalInventory::Orchestrator::TestModels::ObjectManager.new(kube_client) }
 
@@ -19,7 +13,7 @@ describe TopologicalInventory::Orchestrator::Worker do
 
   subject do
     allow(described_class).to receive(:path_to_config).and_return(File.expand_path("../config", File.dirname(__FILE__)))
-    described_class.new(:collector_image_tag => "dev", :sources_api => sources_api, :topology_api => topology_api)
+    described_class.new(:sources_api => sources_api, :topology_api => topology_api)
   end
 
   before do
@@ -90,7 +84,7 @@ describe TopologicalInventory::Orchestrator::Worker do
         object_manager.create_secret("secret_#{version}", {}) do |secret|
           secret[:metadata][:labels][TopologicalInventory::Orchestrator::Secret::LABEL_COMMON] = version
         end
-        object_manager.create_deployment_config("dc_#{version}", 'my-namespace', 'image') do |dc|
+        object_manager.create_deployment_config("dc_#{version}", "openshift") do |dc|
           dc[:metadata][:labels][TopologicalInventory::Orchestrator::DeploymentConfig::LABEL_COMMON] = version
         end
       end


### PR DESCRIPTION
Updating orchestrator to be a bit smarter, go off of the currently running operations pods for collector definitions rather than just using what orchestrator is running. 

\# TODO: 
- [x] Pull collector image from running operations pods
- [x] specs for deployment_config.rb
- [x] store currently-running tag (git sha) in the ConfigMap resource
- [x] redeploy worker if tag changes
- [x] ~specs for update-process~ included in the configmap digest logic already