### PR TITLE
Force Sync of Collector Images if DeploymentConfig was not re-created

### DIFF
--- a/lib/topological_inventory/orchestrator/object_manager.rb
+++ b/lib/topological_inventory/orchestrator/object_manager.rb
@@ -41,6 +41,10 @@ module TopologicalInventory
         raise unless e.message =~ /already exists/
       end
 
+      def update_deployment_config(deployment_config_name, patch)
+        connection.patch_deployment_config(deployment_config_name, patch, my_namespace)
+      end
+
       def delete_deployment_config(name)
         rc = kube_connection.get_replication_controllers(
           :label_selector => "openshift.io/deployment-config.name=#{name}",

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -71,6 +71,10 @@ module TopologicalInventory
         # Adds or removes sources to/from openshift
         manage_openshift_collectors
 
+        # Sync the collector images for each configmap just in case an image changed
+        # but the config map stayed the same
+        sync_collector_images
+
         # Remove unused openshift objects
         remove_old_deployments
         remove_old_secrets
@@ -236,6 +240,15 @@ module TopologicalInventory
           else
             logger.debug("Source not changed (#{source})")
           end
+        end
+      end
+
+      def sync_collector_images
+        @config_maps_by_uid.values.each do |cm|
+          # Only sync if the image has changed
+          next if cm.source_type["collector_image"] == cm.deployment_config.image
+
+          cm.deployment_config.update_image(cm.source_type["collector_image"])
         end
       end
 


### PR DESCRIPTION
So after testing a bit today I found if the configmap doesn't get completely deleted it won't create a new DeploymentConfig with the new image, this alleviates that by running a "sync" between the config_maps/deployment_configs on their images. 

\# TODO: 
- [x] specs

cc @syncrou @gmcculloug 