### PR TITLE
Move Scheduled Sync Event to an ENV var rather than a config-file setting

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -9,4 +9,3 @@ labels:
   version: "v1"
 sync:
   poll_time_seconds: 10
-  scheduled_event_hours: 1

--- a/lib/topological_inventory/orchestrator/event_manager.rb
+++ b/lib/topological_inventory/orchestrator/event_manager.rb
@@ -51,7 +51,7 @@ module TopologicalInventory
           queue.push(:event_name => "Scheduled.Sync",
                      :model      => nil)
 
-          sleep((::Settings.sync.scheduled_event_hours || 1).hours)
+          sleep((ENV["SCHEDULED_SYNC_HOURS"]&.to_i || 1).hours)
         end
       end
 


### PR DESCRIPTION
Related: https://github.com/RedHatInsights/e2e-deploy/pull/2022

This will still default to 1 hour, but we can override this a bit easier per-env. 