### PR TITLE
Update Source#digest to account for receptor-enabled sources

### DIFF
--- a/lib/topological_inventory/orchestrator/source.rb
+++ b/lib/topological_inventory/orchestrator/source.rb
@@ -67,7 +67,10 @@ module TopologicalInventory
 
       def digest(reload: false)
         return @digest if @digest.present? && !reload
-        return nil if attributes.nil? || endpoint.nil? || authentication.nil? || credentials.nil?
+        return nil if attributes.nil? || endpoint.nil?
+
+        # If we are not going through a receptor node
+        return nil if endpoint["receptor_node"].blank? && (authentication.nil? || credentials.nil?)
 
         @digest = compute_digest(digest_values)
       end
@@ -88,8 +91,8 @@ module TopologicalInventory
           "source_id"       => attributes["id"],
           "source_uid"      => attributes["uid"],
           "secret"          => {
-            "password" => credentials["password"],
-            "username" => credentials["username"],
+            "password" => credentials.try(:[], "password"),
+            "username" => credentials.try(:[], "username"),
           }
         }
         # Azure has extra parameter "tenant_id"


### PR DESCRIPTION
We weren't accounting for receptor-enabled sources in the `Source` file yet - thus the digest wasn't being computed so the collectors weren't getting spun up. This adds a check for `receptor_node` and handles it appropriately.
