### PR TITLE
Change SCHEDULED_SYNC_HOURS from integer to float

### DIFF
--- a/lib/topological_inventory/orchestrator/event_manager.rb
+++ b/lib/topological_inventory/orchestrator/event_manager.rb
@@ -51,7 +51,7 @@ module TopologicalInventory
           queue.push(:event_name => "Scheduled.Sync",
                      :model      => nil)
 
-          sleep((ENV["SCHEDULED_SYNC_HOURS"]&.to_i || 1).hours)
+          sleep((ENV["SCHEDULED_SYNC_HOURS"]&.to_f || 1).hours)
         end
       end
 


### PR DESCRIPTION
This would truncate if `0.5` was used for example. Found when making sure the code was on CI.