### PR TITLE
Add ENV vars so we can modify collector resource definitions on the fly

### DIFF
--- a/lib/topological_inventory/orchestrator/object_manager.rb
+++ b/lib/topological_inventory/orchestrator/object_manager.rb
@@ -269,12 +269,12 @@ module TopologicalInventory
                   :image     => image,
                   :resources => {
                     :limits   => {
-                      :cpu    => "50m",
-                      :memory => "400Mi"
+                      :cpu    => ENV["COLLECTOR_LIMIT_CPU"] || "100m",
+                      :memory => ENV["COLLECTOR_LIMIT_MEM"] || "500Mi"
                     },
                     :requests => {
-                      :cpu    => "20m",
-                      :memory => "200Mi"
+                      :cpu    => ENV["COLLECTOR_REQUEST_CPU"] || "50m",
+                      :memory => ENV["COLLECTOR_REQUEST_MEM"] || "200Mi"
                     }
                   }
                 }],


### PR DESCRIPTION
This way we do not have to ship a code change in order to tweak the cpu/memory allocation.

e2e-deploy PR: https://github.com/RedHatInsights/e2e-deploy/pull/2073