### PR TITLE
Clean up the dead deploy pods that OSDv4 apparently doesn't do for us anymore

### DIFF
--- a/lib/topological_inventory/orchestrator/object_manager.rb
+++ b/lib/topological_inventory/orchestrator/object_manager.rb
@@ -25,6 +25,10 @@ module TopologicalInventory
         kube_connection.get_pods(:namespace => my_namespace)
       end
 
+      def delete_pod(name)
+        kube_connection.delete_pod(name, my_namespace)
+      end
+
       def get_deployment_config(name)
         connection.get_deployment_config(name, my_namespace)
       end


### PR DESCRIPTION
OSDv4 doesn't like deploymentconfigs anymore, so it doesn't clean up the deploy pods and makes us look at them (in shame).

This PR makes orchestrator clean them up for us.

\# TODO:
- [x] specs

cc @syncrou 