### PR TITLE
Pin CloudWatchLogger to 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem "activesupport",        '~> 5.2.4.3'
-gem "cloudwatchlogger",     "~> 0.2"
+gem "cloudwatchlogger",     "~> 0.2.1"
 gem "config",               "~> 1.7.2"
 gem "http",                 "~> 4.1.1"
 gem "kubeclient",           "~> 4.0"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-persister/issues/70

CloudWatchLogger 0.3.0 is not compatible