### PR TITLE
change uri for openshift v4 connection

### DIFF
--- a/lib/topological_inventory/orchestrator/object_manager.rb
+++ b/lib/topological_inventory/orchestrator/object_manager.rb
@@ -185,7 +185,7 @@ module TopologicalInventory
         v3_connection = raw_connect(manager_uri("/oapi"))
         return v3_connection if client_connection_valid?(v3_connection)
 
-        v4_connection = raw_connect(manager_uri("/apis"), "apps.openshift.io/v1")
+        v4_connection = raw_connect(manager_uri("/apis/apps.openshift.io"))
         return v4_connection if client_connection_valid?(v4_connection)
 
         raise "Failed to detect a valid OpenShift connection"

--- a/spec/topological_inventory/orchestrator/object_manager_spec.rb
+++ b/spec/topological_inventory/orchestrator/object_manager_spec.rb
@@ -80,7 +80,7 @@ describe TopologicalInventory::Orchestrator::ObjectManager do
       URI::HTTPS.build(
         :host => kube_service_host,
         :port => kube_service_port,
-        :path => "/apis"
+        :path => "/apis/apps.openshift.io"
       )
     end
 
@@ -110,7 +110,7 @@ describe TopologicalInventory::Orchestrator::ObjectManager do
     context "when the v3 connection is not available" do
       before do
         expect(v3_connection).to receive(:discover).and_raise(kube_resource_error)
-        expect(instance).to receive(:raw_connect).with(v4_uri, "apps.openshift.io/v1").and_return(v4_connection)
+        expect(instance).to receive(:raw_connect).with(v4_uri).and_return(v4_connection)
       end
 
       it "returns the v4 connection when it is available" do


### PR DESCRIPTION
It looks like we were falling back to the old `/oapi` version of the api until recently, which led us to find that the URI seems to have been wrong for OCPv4. I tested this on OCPv3 and it appears to have worked, I also tested it locally via kubeclient to make sure this will work. 

Hopefully this fixes why orchestrator is failing to run `discover` in stage.

```ruby
[1] pry(main)> @kube
=> #<Kubeclient::Client:0x0000561740c4de40
 @api_endpoint=#<URI::HTTPS https://api.crc-stg-01.o4v9.p1.openshiftapps.com:6443/apis/apps.openshift.io>,
 @api_group="apps.openshift.io/",
 @api_version="v1",
 @as=:ros,
 @auth_options={:bearer_token=>"token"},
 @discovered=false,
 @entities={},
 @headers={:Authorization=>"Bearer token"},
 @http_max_redirects=10,
 @http_proxy_uri=nil,
 @socket_options={:socket_class=>nil, :ssl_socket_class=>nil},
 @ssl_options={:verify_ssl=>0},
 @timeouts={:open=>60, :read=>60}>
[2] pry(main)> @kube.discover
=> true
[3] pry(main)> @kube.get_deployment_configs(:namespace => "topological-inventory-stage").count
=> 3
[4] pry(main)> 
```