### PR TITLE
Retry Collector Deployments if the availableReplicas are 0

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -11,4 +11,14 @@ def default_worker
   TopologicalInventory::Orchestrator::Worker.new(sources_api: ENV["SOURCES_API"], topology_api: ENV["TOPOLOGICAL_INVENTORY_API"])
 end
 
+def populated_worker
+  default_worker.tap do |w|
+    w.send(:load_source_types)
+    w.send(:load_sources)
+    w.send(:load_config_maps)
+    w.send(:load_secrets)
+    w.send(:load_deployment_configs)
+  end
+end
+
 IRB.start

--- a/lib/topological_inventory/orchestrator/object_manager.rb
+++ b/lib/topological_inventory/orchestrator/object_manager.rb
@@ -31,6 +31,9 @@ module TopologicalInventory
 
       def get_deployment_config(name)
         connection.get_deployment_config(name, my_namespace)
+      rescue KubeException
+        logger.warn("[WARN] Deployment Config not found: #{name}")
+        nil
       end
 
       def get_deployment_configs(label_selector)

--- a/spec/topological_inventory/orchestrator/test_models/kube_resource.rb
+++ b/spec/topological_inventory/orchestrator/test_models/kube_resource.rb
@@ -4,6 +4,8 @@ module TopologicalInventory
       class KubeResource < ::Kubeclient::Resource
         def initialize(hash = nil, args = {})
           hash[:data] = encode_secrets(hash.delete(:stringData)) if hash.present? && hash.key?(:stringData)
+          hash[:status] = {:availableReplicas => 1} unless hash[:status]
+
           super(hash, args)
         end
 


### PR DESCRIPTION
Currently seeing an issue on stage where a Collector failed to fire up (we were over the quota), this change makes the orchestrator delete the old dc and retry creating it.

\# TODO:
- [x] specs
