### PR TITLE
Added collector refresh frequency envs

### DIFF
--- a/lib/topological_inventory/orchestrator/deployment_config.rb
+++ b/lib/topological_inventory/orchestrator/deployment_config.rb
@@ -168,6 +168,8 @@ module TopologicalInventory
         [
           {:name => "INGRESS_API", :value => "http://#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"]}:#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_PORT"]}"},
           {:name => "CONFIG", :value => 'custom'},
+          {:name => "COLLECTOR_FULL_REFRESH_FREQUENCY", :value => '3600'},   # tower-related only
+          {:name => "COLLECTOR_PARTIAL_REFRESH_FREQUENCY", :value => '300'}, # tower-related only
           {:name => "CLOUD_WATCH_LOG_GROUP", :value => ENV["CLOUD_WATCH_LOG_GROUP"]},
           {:name => "CW_AWS_ACCESS_KEY_ID", :valueFrom => {:secretKeyRef => {:name => 'cloudwatch', :key => 'aws_access_key_id'}}},
           {:name => "CW_AWS_SECRET_ACCESS_KEY", :valueFrom => {:secretKeyRef => {:name => 'cloudwatch', :key => 'aws_secret_access_key'}}},


### PR DESCRIPTION
Added Ansible Tower-related ENVs:
- COLLECTOR_FULL_REFRESH_FREQUENCY
- COLLECTOR_PARTIAL_REFRESH_FREQUENCY

---

**used by** https://github.com/RedHatInsights/topological_inventory-ansible_tower/pull/136

---

[RHCLOUD-9410](https://issues.redhat.com/browse/RHCLOUD-9410)