### PR TITLE
Add log statements to Object Manager

### DIFF
--- a/lib/topological_inventory/orchestrator/object_manager.rb
+++ b/lib/topological_inventory/orchestrator/object_manager.rb
@@ -4,6 +4,7 @@ require "more_core_extensions/core_ext/string/iec60027_2"
 module TopologicalInventory
   module Orchestrator
     class ObjectManager
+      include Logging
       TOKEN_FILE   = "/run/secrets/kubernetes.io/serviceaccount/token".freeze
       CA_CERT_FILE = "/run/secrets/kubernetes.io/serviceaccount/ca.crt".freeze
 
@@ -50,6 +51,7 @@ module TopologicalInventory
         connection.create_deployment_config(definition)
       rescue KubeException => e
         raise unless e.message =~ /already exists/
+        logger.warn("[WARN] Deployment Config already exists: #{name}")
       end
 
       def update_deployment_config(deployment_config_name, patch)
@@ -72,6 +74,7 @@ module TopologicalInventory
         connection.delete_deployment_config(name, my_namespace, :delete_options => delete_options)
         delete_replication_controller(rc.metadata.name) if rc
       rescue Kubeclient::ResourceNotFoundError
+        logger.warn("[WARN] Deployment Config does not exist: #{name}")
       end
 
       def get_secrets(label_selector)
@@ -87,6 +90,7 @@ module TopologicalInventory
         kube_connection.create_secret(definition)
       rescue KubeException => e
         raise unless e.message =~ /already exists/
+        logger.warn("[WARN] Secret already exists: #{name}")
       end
 
       def update_secret(secret)
@@ -96,6 +100,7 @@ module TopologicalInventory
       def delete_secret(name)
         kube_connection.delete_secret(name, my_namespace)
       rescue Kubeclient::ResourceNotFoundError
+        logger.warn("[WARN] Secret not found: #{name}")
       end
 
       def create_config_map(name)
@@ -104,6 +109,7 @@ module TopologicalInventory
         kube_connection.create_config_map(definition)
       rescue KubeException => e
         raise unless e.message =~ /already exists/
+        logger.warn("[WARN] ConfigMap already exists: #{name}")
       end
 
       def get_config_maps(label_selector)
@@ -128,6 +134,7 @@ module TopologicalInventory
       def delete_replication_controller(name)
         kube_connection.delete_replication_controller(name, my_namespace)
       rescue Kubeclient::ResourceNotFoundError
+        logger.warn("[WARN] ReplicationController not found: #{name}")
       end
 
       def get_collector_image(name)


### PR DESCRIPTION
Bugging out on stage because the `include Logging` statement wasn't at the top, went ahead and added some more logging as well in the exception blocks. 