### PR TITLE
Orchestrator: Custom metrics

### DIFF
--- a/bin/metrics_scaler
+++ b/bin/metrics_scaler
@@ -11,10 +11,10 @@ args = Optimist.options do
   opt :prometheus_port, "Port of the prometheus metrics server", :type => :integer, :default => ENV['PROMETHEUS_PORT']&.to_i
 end
 
-require "topological_inventory/orchestrator/application_metrics"
+require "topological_inventory/orchestrator/metrics/metrics_scaler"
 require "topological_inventory/orchestrator/metric_scaler"
 
-metrics = TopologicalInventory::Orchestrator::ApplicationMetrics.new(args[:metrics_port])
+metrics = TopologicalInventory::Orchestrator::Metrics::MetricsScaler.new(args[:metrics_port])
 
 Signal.trap("TERM") do
   metrics.stop_server

--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -8,7 +8,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 def parse_args
   require 'optimist'
   opts = Optimist.options do
-    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics", :type => :integer, :default => 9394
+    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics", :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
     opt :sources_api, "URL to the sources service, e.g. http://localhost:3000/api/v1.0", :type => :string,
         :default => ENV["SOURCES_API"], :required => ENV["SOURCES_API"].nil?
     opt :topology_api, "URL to the topological inventory service, e.g. http://localhost:4000/api/v0.1", :type => :string,
@@ -22,11 +22,11 @@ def parse_args
 end
 
 require "topological_inventory-orchestrator"
-require "topological_inventory/orchestrator/application_metrics"
+require "topological_inventory/orchestrator/metrics/orchestrator"
 
 args = parse_args
 
-metrics = TopologicalInventory::Orchestrator::ApplicationMetrics.new(args[:metrics_port])
+metrics = TopologicalInventory::Orchestrator::Metrics::Orchestrator.new(args[:metrics_port])
 
 Signal.trap("TERM") do
   metrics.stop_server
@@ -37,6 +37,7 @@ w = TopologicalInventory::Orchestrator::Worker.new(
   :sources_api  => args[:sources_api],
   :topology_api => args[:topology_api],
   :config_name  => args[:config],
-  :source_types => args[:source_types]&.split(",")
+  :source_types => args[:source_types]&.split(","),
+  :metrics      => metrics
 )
 w.run

--- a/lib/topological_inventory/orchestrator/config_map.rb
+++ b/lib/topological_inventory/orchestrator/config_map.rb
@@ -160,9 +160,9 @@ module TopologicalInventory
       def create_in_openshift(source)
         logger.info("Creating ConfigMap #{self} by Source #{source}")
 
-        object_manager.create_config_map(name) do |map|
+        object_manager.create_config_map(name, source_type_name) do |map|
           map[:metadata][:labels][LABEL_COMMON] = ::Settings.labels.version.to_s
-          map[:metadata][:labels][LABEL_SOURCE_TYPE] = source_type['name'] if source_type.present?
+          map[:metadata][:labels][LABEL_SOURCE_TYPE] = source_type_name if source_type.present?
           map[:metadata][:labels][LABEL_UNIQUE] = uid
           map[:data][:uid] = uid
           map[:data][:digests] = [source.digest].to_json
@@ -216,14 +216,13 @@ module TopologicalInventory
 
         logger.info("Deleting ConfigMap #{self}")
 
-        object_manager.delete_config_map(name)
+        object_manager.delete_config_map(name, source_type_name)
 
         logger.info("[OK] Deleted ConfigMap #{self}")
       end
 
       def name
-        type_name = source_type.present? ? source_type['name'] : 'unknown'
-        "config-#{type_name}-#{uid}"
+        "config-#{source_type_name}-#{uid}"
       end
 
       # New ConfigMap is associated with random UUID
@@ -401,6 +400,10 @@ module TopologicalInventory
         else
           sources.size
         end
+      end
+
+      def source_type_name
+        source_type.try(:[], 'name') || 'unknown'
       end
 
       def new_secret

--- a/lib/topological_inventory/orchestrator/deployment_config.rb
+++ b/lib/topological_inventory/orchestrator/deployment_config.rb
@@ -29,7 +29,7 @@ module TopologicalInventory
         end
 
         logger.info("Creating DeploymentConfig #{self}")
-        object_manager.create_deployment_config(name, config_map.source_type["collector_image"]) do |dc|
+        object_manager.create_deployment_config(name, config_map.source_type["collector_image"], source_type_name) do |dc|
           dc[:metadata][:labels][LABEL_UNIQUE] = uid
           dc[:metadata][:labels][LABEL_COMMON] = ::Settings.labels.version.to_s
           dc[:metadata][:labels][ConfigMap::LABEL_SOURCE_TYPE] = config_map.source_type['name'] if config_map.source_type.present?
@@ -68,7 +68,7 @@ module TopologicalInventory
       def delete_in_openshift
         logger.info("Deleting DeploymentConfig #{self}")
 
-        object_manager.delete_deployment_config(name)
+        object_manager.delete_deployment_config(name, source_type_name)
 
         logger.info("[OK] Deleted DeploymentConfig #{self}")
       end
@@ -184,6 +184,10 @@ module TopologicalInventory
 
       def load_openshift_object
         object_manager.get_deployment_configs(LABEL_COMMON).detect { |s| s.metadata.labels[LABEL_UNIQUE] == uid }
+      end
+
+      def source_type_name
+        config_map&.source_type.try(:[], 'name') || 'unknown'
       end
     end
   end

--- a/lib/topological_inventory/orchestrator/event_manager.rb
+++ b/lib/topological_inventory/orchestrator/event_manager.rb
@@ -9,6 +9,8 @@ module TopologicalInventory
     class EventManager
       include Logging
 
+      delegate :metrics, :to => :worker
+
       def self.run!(worker)
         manager = new(worker)
         manager.run!
@@ -80,6 +82,8 @@ module TopologicalInventory
         full_sync = false
 
         events.each do |event|
+          metrics&.record_event(event[:event_name])
+
           if event[:event_name] == 'Scheduled.Sync'
             full_sync = true
             break
@@ -96,6 +100,7 @@ module TopologicalInventory
         end
       rescue => e
         logger.error("#{e.message}\n#{e.backtrace.join('\n')}")
+        metrics&.record_error(:event_manager)
       end
 
       def persist_ref

--- a/lib/topological_inventory/orchestrator/metric_scaler.rb
+++ b/lib/topological_inventory/orchestrator/metric_scaler.rb
@@ -44,7 +44,7 @@ module TopologicalInventory
         if dc.metadata.annotations["metric_scaler_prometheus_query"]
           PrometheusWatcher.new(@metrics, dc, dc_name, @prometheus_hostname, logger)
         else
-          Watcher.new(dc, dc_name, logger)
+          Watcher.new(@metrics, dc, dc_name, logger)
         end
       end
 

--- a/lib/topological_inventory/orchestrator/metric_scaler.rb
+++ b/lib/topological_inventory/orchestrator/metric_scaler.rb
@@ -49,7 +49,7 @@ module TopologicalInventory
       end
 
       def object_manager
-        @object_manager ||= ObjectManager.new
+        @object_manager ||= ObjectManager.new(@metrics)
       end
     end
   end

--- a/lib/topological_inventory/orchestrator/metric_scaler/prometheus_watcher.rb
+++ b/lib/topological_inventory/orchestrator/metric_scaler/prometheus_watcher.rb
@@ -62,15 +62,15 @@ module TopologicalInventory
           metrics.to_a
         rescue RestClient::BadRequest => e
           logger.error("PrometheusWatcher: Bad request: #{e.response.body}")
-          @prometheus.record_metric_scaler_error
+          @prometheus.record_error
           []
         rescue RestClient::ExceptionWithResponse => e
           logger.error("PrometheusWatcher: RestClient error: #{e.message}")
-          @prometheus.record_metric_scaler_error
+          @prometheus.record_error
           []
         rescue => e
           logger.error("PrometheusWatcher: #{e.message}\n#{e.backtrace.join("\n")}")
-          @prometheus.record_metric_scaler_error
+          @prometheus.record_error
           []
         end
 

--- a/lib/topological_inventory/orchestrator/metric_scaler/prometheus_watcher.rb
+++ b/lib/topological_inventory/orchestrator/metric_scaler/prometheus_watcher.rb
@@ -9,9 +9,8 @@ module TopologicalInventory
         METRICS_STEP           = "1m"
 
         def initialize(exporter, deployment_config, deployment_config_name, prometheus_host, logger)
-          super(deployment_config, deployment_config_name, logger)
+          super(exporter, deployment_config, deployment_config_name, logger)
           @prometheus_host = prometheus_host
-          @prometheus = exporter
           @scaling_allowed.value = false
         end
 

--- a/lib/topological_inventory/orchestrator/metric_scaler/watcher.rb
+++ b/lib/topological_inventory/orchestrator/metric_scaler/watcher.rb
@@ -8,11 +8,12 @@ module TopologicalInventory
 
         attr_reader :deployment_config, :deployment_config_name, :logger, :finished, :thread
 
-        def initialize(deployment_config, deployment_config_name, logger)
+        def initialize(metrics, deployment_config, deployment_config_name, logger)
           @deployment_config   = deployment_config
           @deployment_config_name = deployment_config_name
           @finished = Concurrent::AtomicBoolean.new(false)
           @logger = logger
+          @prometheus = metrics
           @scaling_allowed = Concurrent::AtomicBoolean.new(true)
 
           logger.info("Metrics scaling enabled for #{deployment_config_name}")
@@ -102,7 +103,7 @@ module TopologicalInventory
 
         def object_manager
           require "topological_inventory/orchestrator/object_manager"
-          @object_manager ||= ObjectManager.new
+          @object_manager ||= ObjectManager.new(@prometheus)
         end
 
         ### Metrics scraping

--- a/lib/topological_inventory/orchestrator/metrics/metrics_scaler.rb
+++ b/lib/topological_inventory/orchestrator/metrics/metrics_scaler.rb
@@ -1,0 +1,19 @@
+require 'topological_inventory/orchestrator/metrics'
+
+module TopologicalInventory
+  module Orchestrator
+    class Metrics
+      class MetricsScaler < TopologicalInventory::Orchestrator::Metrics
+        ERROR_COUNTER_MESSAGE = "total number of times the metric_scaler has failed to hit prometheus".freeze
+
+        def configure_metrics
+          super
+        end
+
+        def default_prefix
+          "topological_inventory_metric_scaler_"
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/metrics/orchestrator.rb
+++ b/lib/topological_inventory/orchestrator/metrics/orchestrator.rb
@@ -4,7 +4,6 @@ module TopologicalInventory
   module Orchestrator
     class Metrics
       class Orchestrator < TopologicalInventory::Orchestrator::Metrics
-
         def record_event(event_name)
           @events_counter&.observe(1, :event_name => event_name.to_s)
         end
@@ -26,7 +25,7 @@ module TopologicalInventory
 
           @config_maps_gauge = PrometheusExporter::Metric::Gauge.new("config_maps", 'number of active collector config maps')
           @deployments_gauge = PrometheusExporter::Metric::Gauge.new("deployment_configs", 'number of active collector deployment configs')
-          @events_counter = PrometheusExporter::Metric::Counter.new("event", "total number of received events")
+          @events_counter = PrometheusExporter::Metric::Counter.new("events_count", "total number of received events")
           @secrets_gauge = PrometheusExporter::Metric::Gauge.new("secrets", 'number of active collector secrets')
 
           @server.collector.register_metric(@events_counter)

--- a/lib/topological_inventory/orchestrator/metrics/orchestrator.rb
+++ b/lib/topological_inventory/orchestrator/metrics/orchestrator.rb
@@ -1,0 +1,44 @@
+require 'topological_inventory/orchestrator/metrics'
+
+module TopologicalInventory
+  module Orchestrator
+    class Metrics
+      class Orchestrator < TopologicalInventory::Orchestrator::Metrics
+
+        def record_event(event_name)
+          @events_counter&.observe(1, :event_name => event_name.to_s)
+        end
+
+        def record_config_maps(opt = :set, value: nil, source_type: :unknown)
+          record_gauge(@config_maps_gauge, opt, :value => value, :labels => {:source_type => source_type.to_s})
+        end
+
+        def record_deployment_configs(opt = :set, value: nil, source_type: :unknown)
+          record_gauge(@deployments_gauge, opt, :value => value, :labels => {:source_type => source_type.to_s})
+        end
+
+        def record_secrets(opt = :set, value: nil, source_type: :unknown)
+          record_gauge(@secrets_gauge, opt, :value => value, :labels => {:source_type => source_type.to_s})
+        end
+
+        def configure_metrics
+          super
+
+          @config_maps_gauge = PrometheusExporter::Metric::Gauge.new("config_maps", 'number of active collector config maps')
+          @deployments_gauge = PrometheusExporter::Metric::Gauge.new("deployment_configs", 'number of active collector deployment configs')
+          @events_counter = PrometheusExporter::Metric::Counter.new("event", "total number of received events")
+          @secrets_gauge = PrometheusExporter::Metric::Gauge.new("secrets", 'number of active collector secrets')
+
+          @server.collector.register_metric(@events_counter)
+          @server.collector.register_metric(@config_maps_gauge)
+          @server.collector.register_metric(@deployments_gauge)
+          @server.collector.register_metric(@secrets_gauge)
+        end
+
+        def default_prefix
+          "topological_inventory_orchestrator_"
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/openshift_object.rb
+++ b/lib/topological_inventory/orchestrator/openshift_object.rb
@@ -5,6 +5,8 @@ module TopologicalInventory
 
       attr_writer :openshift_object
 
+      delegate :metrics, :to => :object_manager
+
       def initialize(object_manager, openshift_object = nil)
         self.object_manager = object_manager
         self.openshift_object = openshift_object

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -2,16 +2,16 @@ describe TopologicalInventory::Orchestrator::Api do
   include MockData
   include Functions
 
-  describe "#internal_url_for" do
-    let(:api) { TopologicalInventory::Orchestrator::Api.new(:sources_api => sources_api, :topology_api => topology_api) }
+  let(:metrics) { double("Metrics/Orchestrator", :record_deployment_configs => nil, :record_config_maps => nil, :record_secrets => nil) }
+  let(:api) { TopologicalInventory::Orchestrator::Api.new(:sources_api => sources_api, :topology_api => topology_api, :metrics => metrics) }
 
+  describe "#internal_url_for" do
     it "replaces the path with /internal/v0.1/<path>" do
       expect(api.send(:topology_internal_url_for, "the/best/path")).to eq("http://topology.local:8080/internal/v1.0/the/best/path")
     end
   end
 
   describe "#each_resource" do
-    let(:api) { TopologicalInventory::Orchestrator::Api.new(:sources_api => sources_api, :topology_api => topology_api) }
     let(:path1) { "/api/topological-inventory/v1.0/some_collection" }
     let(:path2) { "/api/topological-inventory/v1.0/some_collection?offset=10&limit=10" }
     let(:path3) { "/api/topological-inventory/v1.0/some_collection?offset=20&limit=10" }

--- a/spec/helpers/functions.rb
+++ b/spec/helpers/functions.rb
@@ -130,7 +130,7 @@ module Functions
   end
 
   def request_filter(filter_key, filter_value, limit: nil)
-    @api ||= TopologicalInventory::Orchestrator::TargetedApi.new(:sources_api => sources_api, :topology_api => topology_api)
+    @api ||= TopologicalInventory::Orchestrator::TargetedApi.new(:metrics => nil, :sources_api => sources_api, :topology_api => topology_api)
     @api.send(:make_params_string, filter_key, filter_value, limit)
   end
 

--- a/spec/metric_scaler_spec.rb
+++ b/spec/metric_scaler_spec.rb
@@ -1,6 +1,4 @@
-require File.join(__dir__, "../lib/topological_inventory/orchestrator/metric_scaler")
-require File.join(__dir__, "../lib/topological_inventory/orchestrator/metric_scaler/watcher")
-require File.join(__dir__, "../lib/topological_inventory/orchestrator/object_manager")
+require "topological_inventory/orchestrator/metric_scaler"
 
 describe TopologicalInventory::Orchestrator::MetricScaler do
   let(:instance) { described_class.new(nil, nil, logger) }
@@ -13,9 +11,9 @@ describe TopologicalInventory::Orchestrator::MetricScaler do
     expect(TopologicalInventory::Orchestrator::ObjectManager).to receive(:new).and_return(object_manager)
     expect(Thread).to receive(:new).and_yield # Sorry, The use of doubles or partial doubles from rspec-mocks outside of the per-test lifecycle is not supported. (RSpec::Mocks::OutsideOfExampleError)
 
-    watcher = described_class::Watcher.new(deployment, deployment.metadata.name, logger)
+    watcher = described_class::Watcher.new(nil, deployment, deployment.metadata.name, logger)
     expect(watcher).not_to receive(:percent_usage_from_metrics)
-    expect(described_class::Watcher).to receive(:new).with(deployment, deployment.metadata.name, logger).and_return(watcher)
+    expect(described_class::Watcher).to receive(:new).with(nil, deployment, deployment.metadata.name, logger).and_return(watcher)
 
     instance.run_once
   end

--- a/spec/topological_inventory/orchestrator/metric_scaler/prometheus_watcher_spec.rb
+++ b/spec/topological_inventory/orchestrator/metric_scaler/prometheus_watcher_spec.rb
@@ -137,7 +137,7 @@ describe TopologicalInventory::Orchestrator::MetricScaler::PrometheusWatcher do
     end
 
     it "logs a metric" do
-      expect(prometheus).to receive(:record_metric_scaler_error).once
+      expect(prometheus).to receive(:record_error).once
 
       watcher.start
       watcher.thread.join

--- a/spec/topological_inventory/orchestrator/metric_scaler/watcher_spec.rb
+++ b/spec/topological_inventory/orchestrator/metric_scaler/watcher_spec.rb
@@ -1,5 +1,5 @@
-require File.join(__dir__, "../../../../lib/topological_inventory/orchestrator/metric_scaler/watcher")
-require File.join(__dir__, "../../../../lib/topological_inventory/orchestrator/object_manager")
+require "topological_inventory/orchestrator/metric_scaler/watcher"
+require "topological_inventory/orchestrator/object_manager"
 
 describe TopologicalInventory::Orchestrator::MetricScaler::Watcher do
   let(:logger) { Logger.new(StringIO.new).tap { |logger| allow(logger).to receive(:info) } }
@@ -19,8 +19,9 @@ describe TopologicalInventory::Orchestrator::MetricScaler::Watcher do
     let(:deployment)     { double("deployment", :metadata => double("metadata", :name => "deployment-#{rand(100..500)}", :annotations => annotations), :spec => double("spec", :replicas => replicas)) }
     let(:metrics)        { watcher.send(:metrics) }
     let(:object_manager) { double("TopologicalInventory::Orchestrator::ObjectManager", :get_deployment_configs => [deployment], :get_deployment_config => deployment) }
+    let(:prometheus)     { double("TopologicalInventory::Orchestrator::Metrics::MetricsScaler") }
     let(:replicas)       { 2 }
-    let(:watcher)        { described_class.new(deployment, deployment.metadata.name, logger) }
+    let(:watcher)        { described_class.new(prometheus, deployment, deployment.metadata.name, logger) }
 
     before { allow(TopologicalInventory::Orchestrator::ObjectManager).to receive(:new).and_return(object_manager) }
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -2,6 +2,7 @@ describe TopologicalInventory::Orchestrator::Worker do
   include Functions
 
   let(:kube_client) { TopologicalInventory::Orchestrator::TestModels::KubeClient.new }
+  let(:metrics) { double('Metrics::Orchestrator') }
   let(:object_manager) { TopologicalInventory::Orchestrator::TestModels::ObjectManager.new(kube_client) }
 
   # Predefined responses
@@ -13,7 +14,7 @@ describe TopologicalInventory::Orchestrator::Worker do
 
   subject do
     allow(described_class).to receive(:path_to_config).and_return(File.expand_path("../config", File.dirname(__FILE__)))
-    described_class.new(:sources_api => sources_api, :topology_api => topology_api)
+    described_class.new(:metrics => metrics, :sources_api => sources_api, :topology_api => topology_api)
   end
 
   before do
@@ -64,6 +65,7 @@ describe TopologicalInventory::Orchestrator::Worker do
       end
 
       expect(subject.send(:object_manager)).to receive(:check_deployment_config_quota).and_raise(::TopologicalInventory::Orchestrator::ObjectManager::QuotaCpuLimitExceeded).exactly(available_sources_size).times
+      expect(metrics).to receive(:record_error).with(:quota_error).exactly(available_sources_size).times
 
       expect(kube_client).not_to receive(:create_deployment_config)
 


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320

Adding prometheus exporter and metrics to the orchestrator.
* event_counter (by event type)
* errors_counter (by error type)
* config maps gauge (by source type)
* deployment configs gauge (by source type)
* secrets gauge (by source type

- [x] TODO: specs

---

[RHCLOUD-9942](https://issues.redhat.com/browse/RHCLOUD-9942)