### PR TITLE
Add LOG_LEVEL ENV var to collectors

### DIFF
--- a/lib/topological_inventory/orchestrator/deployment_config.rb
+++ b/lib/topological_inventory/orchestrator/deployment_config.rb
@@ -166,6 +166,7 @@ module TopologicalInventory
 
       def container_env_values
         [
+          {:name => "LOG_LEVEL", :value => ENV['COLLECTOR_LOG_LEVEL'] || "WARN"},
           {:name => "INGRESS_API", :value => "http://#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"]}:#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_PORT"]}"},
           {:name => "CONFIG", :value => 'custom'},
           {:name => "COLLECTOR_FULL_REFRESH_FREQUENCY", :value => '3600'},   # tower-related only


### PR DESCRIPTION
So we have the `LOG_LEVEL` settings already in providers common: https://github.com/RedHatInsights/topological_inventory-providers-common/blob/792b61f6cb7b3b6af6e4b180847c36a51dbbb83f/lib/topological_inventory/providers/common/logging.rb#L41

We just need to pass it through. I will have someone from AppSRE edit the currently running collectors - but this will fix it for the future. 
