### PR TITLE
Add LOG_LEVEL setting for CloudWatch Logger

### DIFF
--- a/lib/topological_inventory/orchestrator/logger.rb
+++ b/lib/topological_inventory/orchestrator/logger.rb
@@ -7,7 +7,7 @@ module TopologicalInventory
     end
 
     def self.logger
-      @logger ||= ManageIQ::Loggers::CloudWatch.new
+      @logger ||= ManageIQ::Loggers::CloudWatch.new.tap { |log| log.level = ENV['LOG_LEVEL'] || "INFO" }
     end
 
     module Logging


### PR DESCRIPTION
Just adding CloudWatch log level settings for orchestrator.

e2e-deploy changes here, (can go before/after): https://github.com/RedHatInsights/e2e-deploy/pull/2437