### PR TITLE
Add Liveness Probe checking Sources, Topology, and k8s APIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN dnf -y --disableplugin=subscription-manager module enable ruby:2.5 && \
       gcc-c++ make redhat-rpm-config \
       # For git based gems
       git \
+      # For checking service status
+      nmap-ncat \
       && \
     dnf --disableplugin=subscription-manager clean all
 

--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -16,6 +16,8 @@ def parse_args
     opt :config, "Configuration YAML file name", :type => :string, :default => ENV["CONFIG"] || 'default'
     opt :source_types, "The Source types to spin up collectors/operations pods for", :type => :string,
         :default => ENV['ENABLED_SOURCE_TYPES']
+    opt :health_check_interval, "The interval to run health-checks against sources/topo/k8s APIs", :type => :integer,
+        :default => (ENV["HEALTH_CHECK_INTERVAL"] || 60).to_i
   end
 
   opts
@@ -38,6 +40,7 @@ w = TopologicalInventory::Orchestrator::Worker.new(
   :topology_api => args[:topology_api],
   :config_name  => args[:config],
   :source_types => args[:source_types]&.split(","),
-  :metrics      => metrics
+  :metrics      => metrics,
+  :health_check_interval => args[:health_check_interval]
 )
 w.run

--- a/lib/topological_inventory/orchestrator/health_check.rb
+++ b/lib/topological_inventory/orchestrator/health_check.rb
@@ -1,0 +1,61 @@
+module TopologicalInventory
+  module Orchestrator
+    class HealthCheck
+      include Logging
+
+      attr_accessor :sources_api, :topology_api, :k8s, :interval
+
+      def initialize(sources_api, topology_api, k8s, interval)
+        @sources_api = sources_api
+        @topology_api = topology_api
+        @k8s = k8s
+        @interval = interval
+      end
+
+      def run
+        loop do
+          checks
+
+          sleep interval
+        end
+      end
+
+      def checks
+        errors = []
+
+        errors << check_url(topology_api)
+        errors << check_url(sources_api)
+        errors << check_k8s(k8s)
+
+        if errors.any?
+          FileUtils.rm_f("/tmp/healthy")
+        else
+          FileUtils.touch("/tmp/healthy")
+        end
+      end
+
+      private
+
+      def check_url(uri)
+        logger.info("[HealthCheck] Checking URL: #{uri}")
+
+        resp = Net::HTTP.get_response(uri.host, "/health", uri.port)
+        # Checking if the response code is 400 or larger
+        # this is the exact same behavior as OCP's http livenessProbe
+        raise if resp.code.to_i >= 400
+      rescue
+        logger.warn("[HealthCheck] Failed URL: #{uri}")
+        :error
+      end
+
+      def check_k8s(k8s)
+        logger.info("[HealthCheck] Checking k8s: #{k8s.send(:connection).api_endpoint}")
+
+        raise if k8s.check_api_status.nil?
+      rescue
+        logger.warn("[HealthCheck] k8s failing")
+        :error
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/object_manager.rb
+++ b/lib/topological_inventory/orchestrator/object_manager.rb
@@ -28,6 +28,12 @@ module TopologicalInventory
         connection.patch_deployment_config(deployment_config_name, { :spec => { :replicas => replicas } }, my_namespace)
       end
 
+      def check_api_status
+        connection.api
+      rescue KubeException
+        nil
+      end
+
       def get_pods
         kube_connection.get_pods(:namespace => my_namespace)
       end

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -14,6 +14,7 @@ require "topological_inventory/orchestrator/api"
 require "topological_inventory/orchestrator/config_map"
 require "topological_inventory/orchestrator/deployment_config"
 require "topological_inventory/orchestrator/event_manager"
+require 'topological_inventory/orchestrator/health_check'
 require "topological_inventory/orchestrator/secret"
 require "topological_inventory/orchestrator/source_type"
 require "topological_inventory/orchestrator/source"
@@ -27,17 +28,19 @@ module TopologicalInventory
 
       ORCHESTRATOR_TENANT = "system_orchestrator".freeze
 
-      attr_reader :api, :enabled_source_types, :metrics
+      attr_reader :api, :enabled_source_types, :metrics, :health_check_interval
 
       def initialize(config_name: 'default',
                      metrics: nil,
                      source_types: %w[amazon ansible-tower azure openshift],
                      sources_api:,
-                     topology_api:)
+                     topology_api:,
+                     health_check_interval: 60)
         @enabled_source_types = source_types
 
         self.metrics     = metrics
         self.config_name = config_name
+        self.health_check_interval = health_check_interval
         initialize_config
 
         @api = Api.new(:metrics => metrics, :sources_api => sources_api, :topology_api => topology_api)
@@ -95,7 +98,7 @@ module TopologicalInventory
                     :source_types_by_id, :sources_by_digest,
                     :config_maps_by_uid, :deployment_configs, :secrets
 
-      attr_writer :metrics
+      attr_writer :metrics, :health_check_interval
 
       def load_source_types
         @source_types_by_id = {}

--- a/spec/topological_inventory/orchestrator/health_check_spec.rb
+++ b/spec/topological_inventory/orchestrator/health_check_spec.rb
@@ -1,0 +1,56 @@
+describe TopologicalInventory::Orchestrator::HealthCheck do
+  let(:object_manager) { double }
+  let(:k8s) { double }
+
+  subject do
+    described_class.new(
+      URI.parse("http://topology:3000/api/topo"),
+      URI.parse("http://sources:3000/api/sources"),
+      object_manager,
+      60
+    )
+  end
+
+  before do
+    allow(object_manager).to receive(:connection).and_return(k8s)
+    allow(k8s).to receive(:api_endpoint).and_return("http://k8s.api/oapi")
+  end
+
+  context "when everything is available" do
+    before do
+      allow(Net::HTTP).to receive(:get_response).and_return(OpenStruct.new(:code => 200))
+      allow(object_manager).to receive(:connection).and_return(k8s)
+      allow(object_manager).to receive(:check_api_status).and_return('{"yes": true}')
+    end
+
+    it "touches the healthy file" do
+      expect(FileUtils).to receive(:touch).with("/tmp/healthy").once
+      expect(object_manager).to receive(:check_api_status).once
+      subject.checks
+    end
+  end
+
+  context "when the apis are not reachable" do
+    before do
+      allow(Net::HTTP).to receive(:get_response).and_return(OpenStruct.new(:code => 400))
+      allow(object_manager).to receive(:check_api_status).and_return('{"yes": true}')
+    end
+
+    it "removes the healthy file" do
+      expect(FileUtils).to receive(:rm_f).with("/tmp/healthy").once
+      subject.checks
+    end
+  end
+
+  context "when k8s is not reachable" do
+    before do
+      allow(Net::HTTP).to receive(:get_response).and_return(OpenStruct.new(:code => 200))
+      allow(object_manager).to receive(:check_api_status).and_return(nil)
+    end
+
+    it "removes the healthy file" do
+      expect(FileUtils).to receive(:rm_f).with("/tmp/healthy").once
+      subject.checks
+    end
+  end
+end


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-10440

Adding a liveness probe for orchestrator. It goes out and checks Sources and Topology for connectivity, then hits the OCP API to see if our auth is working.
