### PR TITLE
Changed metric error -> errors_total

### DIFF
--- a/lib/topological_inventory/orchestrator/metrics.rb
+++ b/lib/topological_inventory/orchestrator/metrics.rb
@@ -45,7 +45,7 @@ module TopologicalInventory
         PrometheusExporter::Instrumentation::Process.start
         PrometheusExporter::Metric::Base.default_prefix = default_prefix
 
-        @error_counter = PrometheusExporter::Metric::Counter.new("error", ERROR_COUNTER_MESSAGE)
+        @error_counter = PrometheusExporter::Metric::Counter.new("errors_total", ERROR_COUNTER_MESSAGE)
         @server.collector.register_metric(@error_counter)
       end
 


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320

Metric with suffix `_error` is not available in list of metrics in prometheus, changing to `_errors_total`

---

[RHCLOUD-9942](https://issues.redhat.com/browse/RHCLOUD-9942)