### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # topological_inventory-orchestrator
 
-[![Build Status](https://api.travis-ci.org/RedHatInsights/topological_inventory-orchestrator.svg)](https://travis-ci.org/RedHatInsights/topological_inventory-orchestrator)
+[![Build Status](https://api.travis-ci.com/RedHatInsights/topological_inventory-orchestrator.svg)](https://travis-ci.com/RedHatInsights/topological_inventory-orchestrator)
 [![Maintainability](https://api.codeclimate.com/v1/badges/3088fd5a5fac20bc5945/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-orchestrator/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/3088fd5a5fac20bc5945/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-orchestrator/test_coverage)
 [![security](https://hakiri.io/github/RedHatInsights/topological_inventory-orchestrator/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-orchestrator/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.